### PR TITLE
Logical Fix for when the McGuffin is set to the Maximum Value

### DIFF
--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -1,7 +1,7 @@
 [
 	{
         "name": "Goal",
-        "requires": "|Memory of a Distant World:80|",
+        "requires": "|Memory of a Distant World:50|",
         "victory": true
     },
     {

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -143,11 +143,11 @@ def before_set_rules(world: World, multiworld: MultiWorld, player: int):
 # Called after rules for accessing regions and locations are created, in case you want to see or modify that information.
 def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     goal_count = get_option_value(multiworld, player, "mcguffins_needed")
-    multiworld.completion_condition[player] = lambda state: state.count("Memory of a Distant World", player) > goal_count
+    multiworld.completion_condition[player] = lambda state: state.count("Memory of a Distant World", player) >= goal_count
     for region in multiworld.get_regions(player):
         for location in region.locations:
             if location.name == "__Manual Game Complete__":
-                location.access_rule = lambda state: state.count("Memory of a Distant World", player) > goal_count
+                location.access_rule = lambda state: state.count("Memory of a Distant World", player) >= goal_count
     pass
 
 # The complete item pool prior to being set for generation is provided here, in case you want to make changes to it


### PR DESCRIPTION
The rule was using > rather than >=, so if there were 50 McGuffins generated, and 50 needed, the Victory Condition was never in logic making the seed unbeatable. Rule is updated to account for this.

Locations was also updated as a "just in case".