### PR TITLE
Fix nondeterministic forced jobs with more than 5 jobs specified

### DIFF
--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -126,7 +126,7 @@ def before_create_items_filler(
     world.random.shuffle(caster)
     world.random.shuffle(ranged)
     world.random.shuffle(doh)
-    force_jobs = list(get_option_value(multiworld, player, "force_jobs"))
+    force_jobs = sorted(get_option_value(multiworld, player, "force_jobs"))
     level_cap = get_option_value(multiworld, player, "level_cap") or LevelCap.range_end
     if force_jobs:
         if len(force_jobs) > 5:


### PR DESCRIPTION
The option value is a set, and sets have nondeterministic iteration order, so the option value needs to be sorted when turning it into a list.

With more than 5 forced jobs, when randomly picking 5, the original order of `force_jobs` could differ on multiple generations with the same seed, resulting in different jobs being picked, causing different 'Levels' items being given the progression classification and changing the generation.