### PR TITLE
Huntsanity

### DIFF
--- a/ArchipelagoXIV/ArchipelagoXIV.csproj
+++ b/ArchipelagoXIV/ArchipelagoXIV.csproj
@@ -25,6 +25,7 @@
         <EmbeddedResource Include="..\src\data\regions.json" Link="regions.json" />
         <EmbeddedResource Include="..\src\hooks\duties.csv" Link="duties.csv" />
         <EmbeddedResource Include="..\src\hooks\fates.csv" Link="fates.csv" />
+        <EmbeddedResource Include="..\src\hooks\hunts.csv" Link="hunts.csv" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ArchipelagoXIV/Data.cs
+++ b/ArchipelagoXIV/Data.cs
@@ -8,6 +8,8 @@ namespace ArchipelagoXIV
 {
     internal static partial class Data
     {
+        internal record NotoriousMonsterInfo(string Name, string Rank, string LocationName);
+
         public static TerritoryType[] Territories { get; private set; } = [];
         public static InstanceContent[] Duties { get; private set; } = [];
         public static ClassJob[] ClassJobs { get; private set; } = [];
@@ -17,6 +19,8 @@ namespace ArchipelagoXIV
         public static IKDRoute[] IKDRoutes { get; private set; }
 
         public static FrozenDictionary<string, Fate> FateTable { get; private set; } = null;
+
+        public static FrozenDictionary<uint, NotoriousMonsterInfo> HuntTable { get; private set; } = FrozenDictionary<uint, NotoriousMonsterInfo>.Empty;
 
         public static Dictionary<string, int> FateLevels = new()
         {
@@ -138,8 +142,10 @@ namespace ArchipelagoXIV
 
         public static void Initialize() {
             var dataManager = DalamudApi.DataManager;
+
             if (dataManager == null)
                 return;
+
             Territories = [.. dataManager.GetExcelSheet<TerritoryType>()];
 
             Duties = [.. dataManager.GetExcelSheet<InstanceContent>()];
@@ -154,7 +160,19 @@ namespace ArchipelagoXIV
 
             IKDRoutes = [.. dataManager.GetExcelSheet<IKDRoute>()];
 
-            FateTable = DalamudApi.DataManager.GetExcelSheet<Fate>().DistinctBy(f => f.Name.ToString()).ToFrozenDictionary(f => f.Name.ToString().ToLower().Replace(",", "").Trim());
+            FateTable = dataManager.GetExcelSheet<Fate>().DistinctBy(f => f.Name.ToString()).ToFrozenDictionary(f => f.Name.ToString().ToLower().Replace(",", "").Trim());
+
+            HuntTable = dataManager.GetExcelSheet<NotoriousMonster>()
+                .Where(nm => nm.Rank is 1 or 2 or 3 && nm.BNpcName.RowId != 0)
+                .DistinctBy(nm => nm.BNpcName.RowId)
+                .ToFrozenDictionary(
+                    nm => nm.BNpcName.RowId,
+                    nm =>
+                    {
+                        var name = nm.BNpcName.Value.Singular.ToString();
+                        var rank = nm.Rank switch { 1 => "B", 2 => "A", _ => "S" };
+                        return new NotoriousMonsterInfo(name, rank, $"{name} (Hunt)");
+                    });
         }
 
         public static ContentFinderCondition GetDuty(uint territoryId) {

--- a/ArchipelagoXIV/Data.cs
+++ b/ArchipelagoXIV/Data.cs
@@ -171,7 +171,7 @@ namespace ArchipelagoXIV
                     {
                         var name = nm.BNpcName.Value.Singular.ToString();
                         var rank = nm.Rank switch { 1 => "B", 2 => "A", _ => "S" };
-                        return new NotoriousMonsterInfo(name, rank, $"{name} (Hunt)");
+                        return new NotoriousMonsterInfo(name, rank, $"Hunt {name}");
                     });
         }
 

--- a/ArchipelagoXIV/Hooks/HuntHooks.cs
+++ b/ArchipelagoXIV/Hooks/HuntHooks.cs
@@ -1,0 +1,97 @@
+using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.ClientState.Objects.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ArchipelagoXIV.Hooks
+{
+    internal class HuntHooks(ApState apState) : IDisposable
+    {
+        // Maps GameObjectId → last known HP so we can detect the alive→dead transition
+        private readonly Dictionary<ulong, uint> _trackedHp = [];
+        // Mobs the local player has interacted with
+        private readonly HashSet<ulong> _playerAttacked = [];
+
+        public void Enable()
+        {
+            DalamudApi.Framework.Update += OnFrameworkUpdate;
+        }
+
+        public void Disable()
+        {
+            DalamudApi.Framework.Update -= OnFrameworkUpdate;
+        }
+
+        private void OnFrameworkUpdate(Dalamud.Plugin.Services.IFramework _)
+        {
+            var localPlayer = DalamudApi.ObjectTable.LocalPlayer;
+            var localPlayerId = localPlayer?.GameObjectId ?? ulong.MaxValue;
+            var playerTargetId = localPlayer?.TargetObjectId ?? ulong.MaxValue;
+
+            var toRemove = new HashSet<ulong>(_trackedHp.Keys);
+
+            foreach (var obj in DalamudApi.ObjectTable)
+            {
+                if (obj is not IBattleNpc bnpc)
+                    continue;
+                if (bnpc.BattleNpcKind != BattleNpcSubKind.Combatant)
+                    continue;
+
+                var id = bnpc.GameObjectId;
+                toRemove.Remove(id);
+
+                // Tag as player-involved if the player is targeting this mob,
+                // or if the mob is targeting the player
+                if (id == playerTargetId || bnpc.TargetObjectId == localPlayerId)
+                    _playerAttacked.Add(id);
+
+                if (_trackedHp.TryGetValue(id, out var lastHp) && lastHp > 0 && bnpc.CurrentHp == 0)
+                {
+                    // Transitioned alive → dead this tick
+                    if (_playerAttacked.Contains(id))
+                        OnHuntKill(bnpc);
+
+                    _trackedHp.Remove(id);
+                    _playerAttacked.Remove(id);
+                    continue;
+                }
+
+                _trackedHp[id] = bnpc.CurrentHp;
+            }
+
+            // remove objects that left the object table without a confirmed HP=0 kill
+            // (like fled out of range, was already dead)
+            foreach (var gone in toRemove)
+            {
+                _trackedHp.Remove(gone);
+                _playerAttacked.Remove(gone);
+            }
+        }
+
+        private void OnHuntKill(IBattleNpc bnpc)
+        {
+            if (!Data.HuntTable.TryGetValue(bnpc.NameId, out var huntInfo))
+            {
+                DalamudApi.PluginLog.Debug($"[Hunt] {bnpc.Name} (NameId={bnpc.NameId}) not in HuntTable, ignoring.");
+                return;
+            }
+
+            DalamudApi.PluginLog.Information($"[Hunt] Killed {huntInfo.Rank}-rank {huntInfo.Name}");
+
+            var loc = apState.MissingLocations?.FirstOrDefault(l => l.Name == huntInfo.LocationName);
+            if (loc == null)
+            {
+                DalamudApi.PluginLog.Information($"[Hunt] {huntInfo.LocationName} not in missing locations (already done or not in this seed).");
+                return;
+            }
+
+            loc.Complete();
+        }
+
+        public void Dispose()
+        {
+            Disable();
+        }
+    }
+}

--- a/ArchipelagoXIV/Hooks/HuntHooks.cs
+++ b/ArchipelagoXIV/Hooks/HuntHooks.cs
@@ -79,7 +79,8 @@ namespace ArchipelagoXIV.Hooks
 
             DalamudApi.PluginLog.Information($"[Hunt] Killed {huntInfo.Rank}-rank {huntInfo.Name}");
 
-            var loc = apState.MissingLocations?.FirstOrDefault(l => l.Name == huntInfo.LocationName);
+            var loc = apState.MissingLocations?.FirstOrDefault(l => string.Equals(l.Name, huntInfo.LocationName, StringComparison.OrdinalIgnoreCase));
+            
             if (loc == null)
             {
                 DalamudApi.PluginLog.Information($"[Hunt] {huntInfo.LocationName} not in missing locations (already done or not in this seed).");

--- a/ArchipelagoXIV/Hooks/HuntHooks.cs
+++ b/ArchipelagoXIV/Hooks/HuntHooks.cs
@@ -86,6 +86,12 @@ namespace ArchipelagoXIV.Hooks
                 return;
             }
 
+            if (!loc.IsAccessible())
+            {
+                DalamudApi.PluginLog.Information($"[Hunt] {huntInfo.LocationName} is not in logic (level or region requirement not met), skipping.");
+                return;
+            }
+
             loc.Complete();
         }
 

--- a/ArchipelagoXIV/Plugin.cs
+++ b/ArchipelagoXIV/Plugin.cs
@@ -21,6 +21,7 @@ namespace ArchipelagoXIV
         internal Events Events { get; }
         internal UIHooks UiHooks { get; }
         internal DeathLinkHooks DLHooks { get; }
+        internal HuntHooks HuntHooks { get; }
         public Configuration Configuration { get; init; }
         public WindowSystem WindowSystem = new("ArchipelagoXIV");
 
@@ -47,6 +48,7 @@ namespace ArchipelagoXIV
             this.Events = new Events(apState);
             this.UiHooks = new UIHooks(apState);
             this.DLHooks = new DeathLinkHooks(apState);
+            this.HuntHooks = new HuntHooks(apState);
 
 
             ConfigWindow = new ConfigWindow(this, this.apState);
@@ -83,6 +85,7 @@ namespace ArchipelagoXIV
             this.Events.Enable();
             UiHooks.Enable();
             DLHooks.Enable();
+            HuntHooks.Enable();
             DalamudApi.Framework.Update += Framework_Update;
             DalamudApi.SetStatusBar("AP Ready");
             DalamudApi.logicBar!.OnClick += (e) => { MainWindow.IsOpen = !MainWindow.IsOpen; };
@@ -150,6 +153,7 @@ namespace ArchipelagoXIV
             Events.Disable();
             UiHooks.Disable();
             DLHooks.Dispose();
+            HuntHooks.Dispose();
             CommandManager.RemoveHandler("/ap");
             CommandManager.RemoveHandler("/ap-connect");
             CommandManager.RemoveHandler("/ap-config");

--- a/ArchipelagoXIV/Rando/APData.cs
+++ b/ArchipelagoXIV/Rando/APData.cs
@@ -75,6 +75,7 @@ namespace ArchipelagoXIV.Rando
         public static readonly Dictionary<string, Region> Regions = [];
         public static readonly Dictionary<string, FishData> FishData = [];
         public static readonly Dictionary<string, int> FateData = [];
+        public static readonly Dictionary<string, int> HuntData = [];
 
         public static Dictionary<string, Dictionary<string, string>> ObsoleteChecks { get; private set; }
 
@@ -129,6 +130,29 @@ namespace ArchipelagoXIV.Rando
                     name += " (FATE)";
                 Aliases[name] = zone.Trim();
                 FateData[name] = level;
+            }
+        }
+
+        public static void LoadHuntsCsv()
+        {
+            // hunts.csv columns: BNpcNameId,Name,Rank,Location,Level,Expansion
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ArchipelagoXIV.hunts.csv");
+            using var reader = new StreamReader(stream);
+            Regex CSVParser = new Regex(",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))");
+            string? line = null;
+            
+            while ((line = reader.ReadLine()) != null)
+            {
+                var row = CSVParser.Split(line);
+                if (row[0].Trim() == "BNpcNameId")
+                    continue;
+
+                var name = $"Hunt {row[1].Trim()}";
+                var zone = row[3].Trim();
+                var level = int.Parse(row[4].Trim());
+
+                Aliases[name] = zone;
+                HuntData[name] = level;
             }
         }
 

--- a/ArchipelagoXIV/Rando/APData.cs
+++ b/ArchipelagoXIV/Rando/APData.cs
@@ -76,6 +76,7 @@ namespace ArchipelagoXIV.Rando
         public static readonly Dictionary<string, FishData> FishData = [];
         public static readonly Dictionary<string, int> FateData = [];
         public static readonly Dictionary<string, int> HuntData = [];
+        public static readonly Dictionary<string, string> HuntRankData = [];
 
         public static Dictionary<string, Dictionary<string, string>> ObsoleteChecks { get; private set; }
 
@@ -140,7 +141,7 @@ namespace ArchipelagoXIV.Rando
             using var reader = new StreamReader(stream);
             Regex CSVParser = new Regex(",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))");
             string? line = null;
-            
+
             while ((line = reader.ReadLine()) != null)
             {
                 var row = CSVParser.Split(line);
@@ -148,11 +149,13 @@ namespace ArchipelagoXIV.Rando
                     continue;
 
                 var name = $"Hunt {row[1].Trim()}";
+                var rank = row[2].Trim();
                 var zone = row[3].Trim();
                 var level = int.Parse(row[4].Trim());
 
                 Aliases[name] = zone;
                 HuntData[name] = level;
+                HuntRankData[name] = rank;
             }
         }
 

--- a/ArchipelagoXIV/Rando/Locations/Location.cs
+++ b/ArchipelagoXIV/Rando/Locations/Location.cs
@@ -210,7 +210,12 @@ namespace ArchipelagoXIV.Rando.Locations
 
         public string DisplayText
         {
-            get => Name + HintText;
+            get
+            {
+                if (APData.HuntRankData.TryGetValue(Name, out var rank) && APData.Aliases.TryGetValue(Name, out var zone))
+                    return $"{Name} ({rank}-Rank, {zone}){HintText}";
+                return Name + HintText;
+            }
         }
 
         public string HintText { get

--- a/ArchipelagoXIV/Rando/Locations/Location.cs
+++ b/ArchipelagoXIV/Rando/Locations/Location.cs
@@ -143,6 +143,10 @@ namespace ArchipelagoXIV.Rando.Locations
             {
                 MeetsRequirements = Logic.Always();
             }
+            else if (APData.HuntData.TryGetValue(Name, out var huntLevel))
+            {
+                MeetsRequirements = Logic.Level(huntLevel);
+            }
             else if (Name == "Return to the Waking Sands")
             {
                 MeetsRequirements = Logic.Always();

--- a/ArchipelagoXIV/Rando/Region.cs
+++ b/ArchipelagoXIV/Rando/Region.cs
@@ -15,6 +15,7 @@ namespace ArchipelagoXIV.Rando
             APData.LoadRegions();
             APData.LoadDutiesCsv();
             APData.LoadFatesCsv();
+            APData.LoadHuntsCsv();
             APData.LoadFish();
             APData.LoadRemoved();
         }

--- a/src/hooks/Data.py
+++ b/src/hooks/Data.py
@@ -13,7 +13,8 @@ from itertools import chain
 # 20,000-29,999: Fish
 # 30,000-39,999: Extra Dungeon checks
 # 40,000-40,499: Boss Goal locations and their clear items
-# 40,500-
+# 45,000-49,999: Hunt Marks (Huntsanity)
+# 50,000-
 
 
 # called after the game.json file has been loaded
@@ -451,6 +452,31 @@ def after_load_progressive_item_file(progressive_item_table: list) -> list:
 
 # called after the locations.json file has been loaded, before any location loading or processing has occurred
 # if you need access to the locations after processing to add ids, etc., you should use the hooks in World.py
+def generate_hunt_list() -> list[dict]:
+    hunt_list = []
+    _id = 45_000
+    huntreader = csv.DictReader(pkgutil.get_data(__name__, "hunts.csv").decode().splitlines(), delimiter=',', quotechar='"')
+    
+    for row in huntreader:
+        row = {k.strip(): v.strip() for k, v in row.items()}
+        rank = row["Rank"]
+        expansion = row["Expansion"]
+        level = row["Level"]
+        
+        hunt_list.append({
+            "id": _id,
+            "name": f"Hunt {row['Name']}",
+            "region": row["Location"],
+            "category": ["Hunt Marks", f"Hunt Marks ({expansion})", f"Hunt Marks ({rank}-Rank)", row["Location"]],
+            "requires": "{anyClassLevel(" + level + ")}",
+            "level": level,
+            "rank": rank,
+        })
+        
+        _id += 1
+        
+    return hunt_list
+
 def after_load_location_file(location_table: list) -> list:
     #add FATE locations
     duty_locations, extra_duty_locations = generate_duty_list()
@@ -461,6 +487,7 @@ def after_load_location_file(location_table: list) -> list:
     location_table.extend(generate_fish_list())
     location_table.extend(extra_duty_locations)
     location_table.extend(generate_victory_locations())
+    location_table.extend(generate_hunt_list())
 
     return location_table
 

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -303,7 +303,7 @@ class Huntsanity(OptionSet):
     - A: A-rank hunts - 2 per zone. Hours of respawn time. Old low level hunts are usually killed on sight and not relayed. Finishing this goal may require a long time.
     - S: S-rank hunts - rare spawns with very long respawn timers. If you use this option, keep an eye on Faloop (or your DC's equivalent) to know when they're up.
 
-    List any wanted ranks. For example [B] / [B, A, S] / ... / omit or [] to disable entirely.
+    List any wanted ranks. For example ["B"] / ["B", "A", "S"] / ... / omit or [] to disable entirely.
     """
     display_name = "Huntsanity"
     valid_keys = {"B", "A", "S"}

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -300,7 +300,7 @@ class Huntsanity(OptionSet):
 
     Each selected rank adds those hunts as checks.
     - B: B-rank hunts - 2 per zone. Respawning indefinitely.
-    - A: A-rank hunts - 2 per zone. Hours of respawn time. Old low level hunts are usually killed on sight and not relayed. Finishing this goal may require a long time.
+    - A: A-rank hunts - 2 per zone. Hours of respawn time. Hunts from expansions older than the most recent two are usually not relayed. Finishing this goal may require a long time.
     - S: S-rank hunts - rare spawns with very long respawn timers. If you use this option, keep an eye on Faloop (or your DC's equivalent) to know when they're up.
 
     List any wanted ranks. For example ["B"] / ["B", "A", "S"] / ... / omit or [] to disable entirely.

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -294,6 +294,21 @@ class FatesPerZone(Range):
     range_start = 0
     range_end = 10
 
+class Huntsanity(OptionSet):
+    """
+    Include Hunt Marks in the location pool.
+
+    Each selected rank adds those hunts as checks.
+    - B: B-rank hunts - 2 per zone. Respawning indefinitely.
+    - A: A-rank hunts - 2 per zone. Hours of respawn time. Old low level hunts are usually killed on sight and not relayed. Finishing this goal may require a long time.
+    - S: S-rank hunts - rare spawns with very long respawn timers. If you use this option, keep an eye on Faloop (or your DC's equivalent) to know when they're up.
+
+    List any wanted ranks. For example [B] / [B, A, S] / ... / omit or [] to disable entirely.
+    """
+    display_name = "Huntsanity"
+    valid_keys = {"B", "A", "S"}
+    default = frozenset()
+
 
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
@@ -324,9 +339,10 @@ def before_options_defined(options: dict) -> dict:
     options["ultimate_count"] = UltimateCount
 
     # Fates
+    options["fates_per_zone"] = FatesPerZone
     options["fatesanity"] = Fatesanity
     options["include_unreasonable_fates"] = UnreasonableFates
-    options["fates_per_zone"] = FatesPerZone
+    options["huntsanity"] = Huntsanity
     # Fish
     options["fishsanity"] = Fishsanity
     options["fishsanity_disable_starting_bait"] = FishsanityDisableStartingBait

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -97,16 +97,29 @@ def before_generate_early(world: World, multiworld: MultiWorld, player: int) -> 
     if goal_level and goal_level > level_cap:
         raise OptionError(f"The selected goal '{goal}' requires level {goal_location.get('level')}, which exceeds the level cap of {level_cap}.")
 
-    has_fates = get_option_value(multiworld, player, 'fatesanity') or get_int_value(multiworld, player, 'fates_per_zone') > 0
+    has_fatesanity = get_option_value(multiworld, player, 'fatesanity')
+    fate_count = get_int_value(multiworld, player, 'fates_per_zone')
+    has_fates = has_fatesanity or fate_count > 0
     has_duties = get_int_value(multiworld, player, 'max_party_size') > 0 and get_int_value(multiworld, player, 'duty_difficulty') > 0
     has_dungeons = get_int_value(multiworld, player, 'dungeon_count') > 0 and has_duties
     has_fish = is_option_enabled(multiworld, player, 'fishsanity')
+    has_hunts = bool(get_option_value(multiworld, player, 'huntsanity'))
 
-    if not has_fates and not has_dungeons and not has_fish:
+    if not has_fates and not has_dungeons and not has_fish and not has_hunts:
         raise OptionError("You can't disable everything.")
 
-    if not has_dungeons and not has_fish and not get_option_value(multiworld, player, 'fatesanity') and get_int_value(multiworld, player, 'fates_per_zone') < 3:
+    if has_hunts and not has_dungeons and not has_fish and (not has_fates or fate_count < 2):
+        raise OptionError("Huntsanity alone does not provide enough locations. Please enable at least 2 fates per zone, duties, or fish alongside it.")
+
+    if (
+        not has_dungeons
+        and not has_fish
+        and not has_fatesanity
+        and not has_hunts
+        and get_int_value(multiworld, player, 'fates_per_zone') < 3
+    ):
         world.options.fates_per_zone.value = 3
+        
 
 
 # Called before regions and locations are created. Not clear why you'd want this, but it's here. Victory location is included, but Victory event is not placed yet.

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -108,8 +108,11 @@ def before_generate_early(world: World, multiworld: MultiWorld, player: int) -> 
     if not has_fates and not has_dungeons and not has_fish and not has_hunts:
         raise OptionError("You can't disable everything.")
 
+    if has_hunts and level_cap < 50:
+        raise OptionError("Huntsanity requires a level cap of at least 50.")
+
     if has_hunts and not has_dungeons and not has_fish and (not has_fates or fate_count < 2):
-        raise OptionError("Huntsanity alone does not provide enough locations. Please enable at least 2 fates per zone, duties, or fish alongside it.")
+        raise OptionError("Enable at least 2 fates per zone, or other locations, to use huntsanity.")
 
     if (
         not has_dungeons

--- a/src/hooks/hunts.csv
+++ b/src/hooks/hunts.csv
@@ -80,36 +80,36 @@ Omni,B,60,Azys Lla,HW
 Campacti,A,60,Azys Lla,HW
 Stench Blossom,A,60,Azys Lla,HW
 Leucrotta,S,60,Azys Lla,HW
-Shadow-dweller Yamini,B,70,The Fringes,SB
-Ouzelum,B,70,The Fringes,SB
-Orcus,A,70,The Fringes,SB
-Erle,A,70,The Fringes,SB
-Udumbara,S,70,The Fringes,SB
-Gauki Strongblade,B,70,The Ruby Sea,SB
-Guhuo Niao,B,70,The Ruby Sea,SB
-Funa Yurei,A,70,The Ruby Sea,SB
-Oni Yumemi,A,70,The Ruby Sea,SB
-Okina,S,70,The Ruby Sea,SB
-Deidar,B,70,Yanxia,SB
-Gyorai Quickstrike,B,70,Yanxia,SB
-Gajasura,A,70,Yanxia,SB
-Angada,A,70,Yanxia,SB
-Gamma,S,70,Yanxia,SB
-Gwas-y-neidr,B,70,The Peaks,SB
-Buccaboo,B,70,The Peaks,SB
-Vochstein,A,70,The Peaks,SB
-Aqrabuamelu,A,70,The Peaks,SB
-Bone Crawler,S,70,The Peaks,SB
-Manes,B,70,The Lochs,SB
-Kiwa,B,70,The Lochs,SB
-Mahisha,A,70,The Lochs,SB
-Luminare,A,70,The Lochs,SB
-Salt and Light,S,70,The Lochs,SB
-Kurma,B,70,The Azim Steppe,SB
-Aswang,B,70,The Azim Steppe,SB
-Girimekhala,A,70,The Azim Steppe,SB
-Sum,A,70,The Azim Steppe,SB
-Orghana,S,70,The Azim Steppe,SB
+Shadow-dweller Yamini,B,70,The Fringes,StB
+Ouzelum,B,70,The Fringes,StB
+Orcus,A,70,The Fringes,StB
+Erle,A,70,The Fringes,StB
+Udumbara,S,70,The Fringes,StB
+Gauki Strongblade,B,70,The Ruby Sea,StB
+Guhuo Niao,B,70,The Ruby Sea,StB
+Funa Yurei,A,70,The Ruby Sea,StB
+Oni Yumemi,A,70,The Ruby Sea,StB
+Okina,S,70,The Ruby Sea,StB
+Deidar,B,70,Yanxia,StB
+Gyorai Quickstrike,B,70,Yanxia,StB
+Gajasura,A,70,Yanxia,StB
+Angada,A,70,Yanxia,StB
+Gamma,S,70,Yanxia,StB
+Gwas-y-neidr,B,70,The Peaks,StB
+Buccaboo,B,70,The Peaks,StB
+Vochstein,A,70,The Peaks,StB
+Aqrabuamelu,A,70,The Peaks,StB
+Bone Crawler,S,70,The Peaks,StB
+Manes,B,70,The Lochs,StB
+Kiwa,B,70,The Lochs,StB
+Mahisha,A,70,The Lochs,StB
+Luminare,A,70,The Lochs,StB
+Salt and Light,S,70,The Lochs,StB
+Kurma,B,70,The Azim Steppe,StB
+Aswang,B,70,The Azim Steppe,StB
+Girimekhala,A,70,The Azim Steppe,StB
+Sum,A,70,The Azim Steppe,StB
+Orghana,S,70,The Azim Steppe,StB
 La Velue,B,80,Lakeland,ShB
 Itzpapalotl,B,80,Lakeland,ShB
 Nuckelavee,A,80,Lakeland,ShB

--- a/src/hooks/hunts.csv
+++ b/src/hooks/hunts.csv
@@ -1,0 +1,202 @@
+Name,Rank,Level,Location,Expansion
+Skogs Fru,B,50,Middle La Noscea,ARR
+Vogaal Ja,A,50,Middle La Noscea,ARR
+Croque-mitaine,S,50,Middle La Noscea,ARR
+Barbastelle,B,50,Lower La Noscea,ARR
+Unktehi,A,50,Lower La Noscea,ARR
+Croakadile,S,50,Lower La Noscea,ARR
+Bloody Mary,B,50,Eastern La Noscea,ARR
+Hellsclaw,A,50,Eastern La Noscea,ARR
+the Garlok,S,50,Eastern La Noscea,ARR
+Dark Helmet,B,50,Western La Noscea,ARR
+Nahn,A,50,Western La Noscea,ARR
+Bonnacon,S,50,Western La Noscea,ARR
+Myradrosh,B,50,Upper La Noscea,ARR
+Marberry,A,50,Upper La Noscea,ARR
+Nandi,S,50,Upper La Noscea,ARR
+Sewer Syrup,B,50,Western Thanalan,ARR
+Alectryon,A,50,Western Thanalan,ARR
+Zona Seeker,S,50,Western Thanalan,ARR
+Ovjang,B,50,Central Thanalan,ARR
+Sabotender Bailarina,A,50,Central Thanalan,ARR
+Brontes,S,50,Central Thanalan,ARR
+Gatling,B,50,Eastern Thanalan,ARR
+Maahes,A,50,Eastern Thanalan,ARR
+Lampalagua,S,50,Eastern Thanalan,ARR
+Albin the Ashen,B,50,Southern Thanalan,ARR
+Zanig'oh,A,50,Southern Thanalan,ARR
+Nunyunuwi,S,50,Southern Thanalan,ARR
+Flame Sergeant Dalvag,B,50,Northern Thanalan,ARR
+Dalvag's Final Flame,A,50,Northern Thanalan,ARR
+Minhocao,S,50,Northern Thanalan,ARR
+White Joker,B,50,Central Shroud,ARR
+Forneus,A,50,Central Shroud,ARR
+Laideronnette,S,50,Central Shroud,ARR
+Stinging Sophie,B,50,East Shroud,ARR
+Melt,A,50,East Shroud,ARR
+Wulgaru,S,50,East Shroud,ARR
+Monarch Ogrefly,B,50,South Shroud,ARR
+Ghede Ti Malice,A,50,South Shroud,ARR
+mindflayer,S,50,South Shroud,ARR
+Phecda,B,50,North Shroud,ARR
+Girtab,A,50,North Shroud,ARR
+Thousand-cast Theda,S,50,North Shroud,ARR
+Naul,B,50,Coerthas Central Highlands,ARR
+Marraco,A,50,Coerthas Central Highlands,ARR
+Safat,S,50,Coerthas Central Highlands,ARR
+Leech King,B,50,Mor Dhona,ARR
+Kurrea,A,50,Mor Dhona,ARR
+Agrippa the Mighty,S,50,Mor Dhona,ARR
+Vuokho,B,50,Outer La Noscea,ARR
+Cornu,A,50,Outer La Noscea,ARR
+Chernobog,S,50,Outer La Noscea,ARR
+Alteci,B,60,Coerthas Western Highlands,HW
+Kreutzet,B,60,Coerthas Western Highlands,HW
+Mirka,A,60,Coerthas Western Highlands,HW
+Lyuba,A,60,Coerthas Western Highlands,HW
+kaiser behemoth,S,60,Coerthas Western Highlands,HW
+Gnath cometdrone,B,60,The Dravanian Forelands,HW
+Thextera,B,60,The Dravanian Forelands,HW
+Pylraster,A,60,The Dravanian Forelands,HW
+Lord of the Wyverns,A,60,The Dravanian Forelands,HW
+Senmurv,S,60,The Dravanian Forelands,HW
+Pterygotus,B,60,The Dravanian Hinterlands,HW
+false gigantopithecus,B,60,The Dravanian Hinterlands,HW
+Slipkinx Steeljoints,A,60,The Dravanian Hinterlands,HW
+Stolas,A,60,The Dravanian Hinterlands,HW
+the Pale Rider,S,60,The Dravanian Hinterlands,HW
+Scitalis,B,60,The Churning Mists,HW
+the Scarecrow,B,60,The Churning Mists,HW
+Bune,A,60,The Churning Mists,HW
+Agathos,A,60,The Churning Mists,HW
+Gandarewa,S,60,The Churning Mists,HW
+Squonk,B,60,The Sea of Clouds,HW
+Sanu Vali of Dancing Wings,B,60,The Sea of Clouds,HW
+Enkelados,A,60,The Sea of Clouds,HW
+Sisiutl,A,60,The Sea of Clouds,HW
+Bird of Paradise,S,60,The Sea of Clouds,HW
+Lycidas,B,60,Azys Lla,HW
+Omni,B,60,Azys Lla,HW
+Campacti,A,60,Azys Lla,HW
+stench blossom,A,60,Azys Lla,HW
+Leucrotta,S,60,Azys Lla,HW
+Shadow-dweller Yamini,B,70,The Fringes,SB
+Ouzelum,B,70,The Fringes,SB
+Orcus,A,70,The Fringes,SB
+Erle,A,70,The Fringes,SB
+Udumbara,S,70,The Fringes,SB
+Gauki Strongblade,B,70,The Ruby Sea,SB
+Guhuo Niao,B,70,The Ruby Sea,SB
+Funa Yurei,A,70,The Ruby Sea,SB
+Oni Yumemi,A,70,The Ruby Sea,SB
+Okina,S,70,The Ruby Sea,SB
+Deidar,B,70,Yanxia,SB
+Gyorai Quickstrike,B,70,Yanxia,SB
+Gajasura,A,70,Yanxia,SB
+Angada,A,70,Yanxia,SB
+Gamma,S,70,Yanxia,SB
+Gwas-y-neidr,B,70,The Peaks,SB
+Buccaboo,B,70,The Peaks,SB
+Vochstein,A,70,The Peaks,SB
+Aqrabuamelu,A,70,The Peaks,SB
+Bone Crawler,S,70,The Peaks,SB
+Manes,B,70,The Lochs,SB
+Kiwa,B,70,The Lochs,SB
+Mahisha,A,70,The Lochs,SB
+Luminare,A,70,The Lochs,SB
+Salt and Light,S,70,The Lochs,SB
+Kurma,B,70,The Azim Steppe,SB
+Aswang,B,70,The Azim Steppe,SB
+Girimekhala,A,70,The Azim Steppe,SB
+Sum,A,70,The Azim Steppe,SB
+Orghana,S,70,The Azim Steppe,SB
+La Velue,B,80,Lakeland,ShB
+Itzpapalotl,B,80,Lakeland,ShB
+Nuckelavee,A,80,Lakeland,ShB
+Nariphon,A,80,Lakeland,ShB
+Tyger,S,80,Lakeland,ShB
+Coquecigrue,B,80,Kholusia,ShB
+Indomitable,B,80,Kholusia,ShB
+Li'l Murderer,A,80,Kholusia,ShB
+Huracan,A,80,Kholusia,ShB
+forgiven pedantry,S,80,Kholusia,ShB
+Worm of the Well,B,80,Amh Araeng,ShB
+Juggler Hecatomb,B,80,Amh Araeng,ShB
+Maliktender,A,80,Amh Araeng,ShB
+Sugaar,A,80,Amh Araeng,ShB
+Tarchia,S,80,Amh Araeng,ShB
+Domovoi,B,80,Il Mheg,ShB
+Vulpangue,B,80,Il Mheg,ShB
+the mudman,A,80,Il Mheg,ShB
+O Poorest Pauldia,A,80,Il Mheg,ShB
+Aglaope,S,80,Il Mheg,ShB
+Mindmaker,B,80,The Rak'tika Greatwood,ShB
+Pachamama,B,80,The Rak'tika Greatwood,ShB
+Supay,A,80,The Rak'tika Greatwood,ShB
+Grassman,A,80,The Rak'tika Greatwood,ShB
+Ixtab,S,80,The Rak'tika Greatwood,ShB
+Gilshs Aath Swiftclaw,B,80,The Tempest,ShB
+Deacon,B,80,The Tempest,ShB
+Rusalka,A,80,The Tempest,ShB
+Baal,A,80,The Tempest,ShB
+Gunitt,S,80,The Tempest,ShB
+green Archon,B,90,Labyrinthos,EW
+ü-u-ü-u,B,90,Labyrinthos,EW
+hulder,A,90,Labyrinthos,EW
+Storsie,A,90,Labyrinthos,EW
+Burfurlur the Canny,S,90,Labyrinthos,EW
+Vajrakumara,B,90,Thavnair,EW
+Iravati,B,90,Thavnair,EW
+Yilan,A,90,Thavnair,EW
+Sugriva,A,90,Thavnair,EW
+Sphatika,S,90,Thavnair,EW
+warmonger,B,90,Garlemald,EW
+Emperor's rose,B,90,Garlemald,EW
+Minerva,A,90,Garlemald,EW
+Aegeiros,A,90,Garlemald,EW
+Armstrong,S,90,Garlemald,EW
+daphnia magna,B,90,Mare Lamentorum,EW
+genesis rock,B,90,Mare Lamentorum,EW
+mousse princess,A,90,Mare Lamentorum,EW
+lunatender queen,A,90,Mare Lamentorum,EW
+Ruminator,S,90,Mare Lamentorum,EW
+level cheater,B,90,Ultima Thule,EW
+Oskh Rhei,B,90,Ultima Thule,EW
+Arch-Eta,A,90,Ultima Thule,EW
+Fan Ail,A,90,Ultima Thule,EW
+Narrow-rift,S,90,Ultima Thule,EW
+Yumcax,B,90,Elpis,EW
+Shockmaw,B,90,Elpis,EW
+petalodus,A,90,Elpis,EW
+Gurangatch,A,90,Elpis,EW
+Ophioneus,S,90,Elpis,EW
+mad maguey,B,100,Urqopacha,DT
+Chupacabra,B,100,Urqopacha,DT
+queen hawk,A,100,Urqopacha,DT
+Nechuciho,A,100,Urqopacha,DT
+Kirlirger the Abhorrent,S,100,Urqopacha,DT
+the Slammer,B,100,Kozama'uka,DT
+go'ozoabek'be,B,100,Kozama'uka,DT
+the Raintriller,A,100,Kozama'uka,DT
+Pkuucha,A,100,Kozama'uka,DT
+Ihnuxokiy,S,100,Kozama'uka,DT
+Leafscourge Hadoll Ja,B,100,Yak T'el,DT
+Xty'iinbek,B,100,Yak T'el,DT
+Rrax Yity'a,A,100,Yak T'el,DT
+Starcrier,A,100,Yak T'el,DT
+Neyoozoteel,S,100,Yak T'el,DT
+nopalitender Fabuloso,B,100,Shaaloani,DT
+Uktena,B,100,Shaaloani,DT
+Yehehetoaua'pyo,A,100,Shaaloani,DT
+Keheniheyamewi,A,100,Shaaloani,DT
+Sansheya,S,100,Shaaloani,DT
+Gallowsbeak,B,100,Heritage Found,DT
+gargant,B,100,Heritage Found,DT
+heshuala,A,100,Heritage Found,DT
+Urna Variabilis,A,100,Heritage Found,DT
+Atticus the Primogenitor,S,100,Heritage Found,DT
+jewel bearer,B,100,Living Memory,DT
+13th Child,B,100,Living Memory,DT
+Sally the Sweeper,A,100,Living Memory,DT
+Cat's Eye,A,100,Living Memory,DT
+the Forecaster,S,100,Living Memory,DT

--- a/src/hooks/hunts.csv
+++ b/src/hooks/hunts.csv
@@ -1,7 +1,7 @@
 Name,Rank,Level,Location,Expansion
 Skogs Fru,B,50,Middle La Noscea,ARR
 Vogaal Ja,A,50,Middle La Noscea,ARR
-Croque-mitaine,S,50,Middle La Noscea,ARR
+Croque-Mitaine,S,50,Middle La Noscea,ARR
 Barbastelle,B,50,Lower La Noscea,ARR
 Unktehi,A,50,Lower La Noscea,ARR
 Croakadile,S,50,Lower La Noscea,ARR

--- a/src/hooks/hunts.csv
+++ b/src/hooks/hunts.csv
@@ -7,7 +7,7 @@ Unktehi,A,50,Lower La Noscea,ARR
 Croakadile,S,50,Lower La Noscea,ARR
 Bloody Mary,B,50,Eastern La Noscea,ARR
 Hellsclaw,A,50,Eastern La Noscea,ARR
-the Garlok,S,50,Eastern La Noscea,ARR
+The Garlok,S,50,Eastern La Noscea,ARR
 Dark Helmet,B,50,Western La Noscea,ARR
 Nahn,A,50,Western La Noscea,ARR
 Bonnacon,S,50,Western La Noscea,ARR
@@ -37,7 +37,7 @@ Melt,A,50,East Shroud,ARR
 Wulgaru,S,50,East Shroud,ARR
 Monarch Ogrefly,B,50,South Shroud,ARR
 Ghede Ti Malice,A,50,South Shroud,ARR
-mindflayer,S,50,South Shroud,ARR
+Mindflayer,S,50,South Shroud,ARR
 Phecda,B,50,North Shroud,ARR
 Girtab,A,50,North Shroud,ARR
 Thousand-cast Theda,S,50,North Shroud,ARR
@@ -54,19 +54,19 @@ Alteci,B,60,Coerthas Western Highlands,HW
 Kreutzet,B,60,Coerthas Western Highlands,HW
 Mirka,A,60,Coerthas Western Highlands,HW
 Lyuba,A,60,Coerthas Western Highlands,HW
-kaiser behemoth,S,60,Coerthas Western Highlands,HW
-Gnath cometdrone,B,60,The Dravanian Forelands,HW
+Kaiser Behemoth,S,60,Coerthas Western Highlands,HW
+Gnath Cometdrone,B,60,The Dravanian Forelands,HW
 Thextera,B,60,The Dravanian Forelands,HW
 Pylraster,A,60,The Dravanian Forelands,HW
 Lord of the Wyverns,A,60,The Dravanian Forelands,HW
 Senmurv,S,60,The Dravanian Forelands,HW
 Pterygotus,B,60,The Dravanian Hinterlands,HW
-false gigantopithecus,B,60,The Dravanian Hinterlands,HW
+False Gigantopithecus,B,60,The Dravanian Hinterlands,HW
 Slipkinx Steeljoints,A,60,The Dravanian Hinterlands,HW
 Stolas,A,60,The Dravanian Hinterlands,HW
-the Pale Rider,S,60,The Dravanian Hinterlands,HW
+The Pale Rider,S,60,The Dravanian Hinterlands,HW
 Scitalis,B,60,The Churning Mists,HW
-the Scarecrow,B,60,The Churning Mists,HW
+The Scarecrow,B,60,The Churning Mists,HW
 Bune,A,60,The Churning Mists,HW
 Agathos,A,60,The Churning Mists,HW
 Gandarewa,S,60,The Churning Mists,HW
@@ -78,7 +78,7 @@ Bird of Paradise,S,60,The Sea of Clouds,HW
 Lycidas,B,60,Azys Lla,HW
 Omni,B,60,Azys Lla,HW
 Campacti,A,60,Azys Lla,HW
-stench blossom,A,60,Azys Lla,HW
+Stench Blossom,A,60,Azys Lla,HW
 Leucrotta,S,60,Azys Lla,HW
 Shadow-dweller Yamini,B,70,The Fringes,SB
 Ouzelum,B,70,The Fringes,SB
@@ -119,7 +119,7 @@ Coquecigrue,B,80,Kholusia,ShB
 Indomitable,B,80,Kholusia,ShB
 Li'l Murderer,A,80,Kholusia,ShB
 Huracan,A,80,Kholusia,ShB
-forgiven pedantry,S,80,Kholusia,ShB
+Forgiven Pedantry,S,80,Kholusia,ShB
 Worm of the Well,B,80,Amh Araeng,ShB
 Juggler Hecatomb,B,80,Amh Araeng,ShB
 Maliktender,A,80,Amh Araeng,ShB
@@ -127,7 +127,7 @@ Sugaar,A,80,Amh Araeng,ShB
 Tarchia,S,80,Amh Araeng,ShB
 Domovoi,B,80,Il Mheg,ShB
 Vulpangue,B,80,Il Mheg,ShB
-the mudman,A,80,Il Mheg,ShB
+The Mudman,A,80,Il Mheg,ShB
 O Poorest Pauldia,A,80,Il Mheg,ShB
 Aglaope,S,80,Il Mheg,ShB
 Mindmaker,B,80,The Rak'tika Greatwood,ShB
@@ -140,9 +140,9 @@ Deacon,B,80,The Tempest,ShB
 Rusalka,A,80,The Tempest,ShB
 Baal,A,80,The Tempest,ShB
 Gunitt,S,80,The Tempest,ShB
-green Archon,B,90,Labyrinthos,EW
-ü-u-ü-u,B,90,Labyrinthos,EW
-hulder,A,90,Labyrinthos,EW
+Green Archon,B,90,Labyrinthos,EW
+Ü-u-ü-u,B,90,Labyrinthos,EW
+Hulder,A,90,Labyrinthos,EW
 Storsie,A,90,Labyrinthos,EW
 Burfurlur the Canny,S,90,Labyrinthos,EW
 Vajrakumara,B,90,Thavnair,EW
@@ -150,34 +150,34 @@ Iravati,B,90,Thavnair,EW
 Yilan,A,90,Thavnair,EW
 Sugriva,A,90,Thavnair,EW
 Sphatika,S,90,Thavnair,EW
-warmonger,B,90,Garlemald,EW
-Emperor's rose,B,90,Garlemald,EW
+Warmonger,B,90,Garlemald,EW
+Emperor's Rose,B,90,Garlemald,EW
 Minerva,A,90,Garlemald,EW
 Aegeiros,A,90,Garlemald,EW
 Armstrong,S,90,Garlemald,EW
-daphnia magna,B,90,Mare Lamentorum,EW
-genesis rock,B,90,Mare Lamentorum,EW
-mousse princess,A,90,Mare Lamentorum,EW
-lunatender queen,A,90,Mare Lamentorum,EW
+Daphnia Magna,B,90,Mare Lamentorum,EW
+Genesis Rock,B,90,Mare Lamentorum,EW
+Mousse Princess,A,90,Mare Lamentorum,EW
+Lunatender Queen,A,90,Mare Lamentorum,EW
 Ruminator,S,90,Mare Lamentorum,EW
-level cheater,B,90,Ultima Thule,EW
+Level Cheater,B,90,Ultima Thule,EW
 Oskh Rhei,B,90,Ultima Thule,EW
 Arch-Eta,A,90,Ultima Thule,EW
 Fan Ail,A,90,Ultima Thule,EW
 Narrow-rift,S,90,Ultima Thule,EW
 Yumcax,B,90,Elpis,EW
 Shockmaw,B,90,Elpis,EW
-petalodus,A,90,Elpis,EW
+Petalodus,A,90,Elpis,EW
 Gurangatch,A,90,Elpis,EW
 Ophioneus,S,90,Elpis,EW
-mad maguey,B,100,Urqopacha,DT
+Mad Maguey,B,100,Urqopacha,DT
 Chupacabra,B,100,Urqopacha,DT
-queen hawk,A,100,Urqopacha,DT
+Queen Hawk,A,100,Urqopacha,DT
 Nechuciho,A,100,Urqopacha,DT
 Kirlirger the Abhorrent,S,100,Urqopacha,DT
-the Slammer,B,100,Kozama'uka,DT
-go'ozoabek'be,B,100,Kozama'uka,DT
-the Raintriller,A,100,Kozama'uka,DT
+The Slammer,B,100,Kozama'uka,DT
+Go'ozoabek'be,B,100,Kozama'uka,DT
+The Raintriller,A,100,Kozama'uka,DT
 Pkuucha,A,100,Kozama'uka,DT
 Ihnuxokiy,S,100,Kozama'uka,DT
 Leafscourge Hadoll Ja,B,100,Yak T'el,DT
@@ -185,18 +185,18 @@ Xty'iinbek,B,100,Yak T'el,DT
 Rrax Yity'a,A,100,Yak T'el,DT
 Starcrier,A,100,Yak T'el,DT
 Neyoozoteel,S,100,Yak T'el,DT
-nopalitender Fabuloso,B,100,Shaaloani,DT
+Nopalitender Fabuloso,B,100,Shaaloani,DT
 Uktena,B,100,Shaaloani,DT
 Yehehetoaua'pyo,A,100,Shaaloani,DT
 Keheniheyamewi,A,100,Shaaloani,DT
 Sansheya,S,100,Shaaloani,DT
 Gallowsbeak,B,100,Heritage Found,DT
-gargant,B,100,Heritage Found,DT
-heshuala,A,100,Heritage Found,DT
+Gargant,B,100,Heritage Found,DT
+Heshuala,A,100,Heritage Found,DT
 Urna Variabilis,A,100,Heritage Found,DT
 Atticus the Primogenitor,S,100,Heritage Found,DT
-jewel bearer,B,100,Living Memory,DT
+Jewel Bearer,B,100,Living Memory,DT
 13th Child,B,100,Living Memory,DT
 Sally the Sweeper,A,100,Living Memory,DT
 Cat's Eye,A,100,Living Memory,DT
-the Forecaster,S,100,Living Memory,DT
+The Forecaster,S,100,Living Memory,DT

--- a/src/hooks/hunts.csv
+++ b/src/hooks/hunts.csv
@@ -1,202 +1,202 @@
-Name,Rank,Level,Location,Expansion
-Skogs Fru,B,50,Middle La Noscea,ARR
-Vogaal Ja,A,50,Middle La Noscea,ARR
-Croque-Mitaine,S,50,Middle La Noscea,ARR
-Barbastelle,B,50,Lower La Noscea,ARR
-Unktehi,A,50,Lower La Noscea,ARR
-Croakadile,S,50,Lower La Noscea,ARR
-Bloody Mary,B,50,Eastern La Noscea,ARR
-Hellsclaw,A,50,Eastern La Noscea,ARR
-The Garlok,S,50,Eastern La Noscea,ARR
-Dark Helmet,B,50,Western La Noscea,ARR
-Nahn,A,50,Western La Noscea,ARR
-Bonnacon,S,50,Western La Noscea,ARR
-Myradrosh,B,50,Upper La Noscea,ARR
-Marberry,A,50,Upper La Noscea,ARR
-Nandi,S,50,Upper La Noscea,ARR
-Sewer Syrup,B,50,Western Thanalan,ARR
-Alectryon,A,50,Western Thanalan,ARR
-Zona Seeker,S,50,Western Thanalan,ARR
-Ovjang,B,50,Central Thanalan,ARR
-Sabotender Bailarina,A,50,Central Thanalan,ARR
-Brontes,S,50,Central Thanalan,ARR
-Gatling,B,50,Eastern Thanalan,ARR
-Maahes,A,50,Eastern Thanalan,ARR
-Lampalagua,S,50,Eastern Thanalan,ARR
-Albin the Ashen,B,50,Southern Thanalan,ARR
-Zanig'oh,A,50,Southern Thanalan,ARR
-Nunyunuwi,S,50,Southern Thanalan,ARR
-Flame Sergeant Dalvag,B,50,Northern Thanalan,ARR
-Dalvag's Final Flame,A,50,Northern Thanalan,ARR
-Minhocao,S,50,Northern Thanalan,ARR
-White Joker,B,50,Central Shroud,ARR
-Forneus,A,50,Central Shroud,ARR
-Laideronnette,S,50,Central Shroud,ARR
-Stinging Sophie,B,50,East Shroud,ARR
-Melt,A,50,East Shroud,ARR
-Wulgaru,S,50,East Shroud,ARR
-Monarch Ogrefly,B,50,South Shroud,ARR
-Ghede Ti Malice,A,50,South Shroud,ARR
-Mindflayer,S,50,South Shroud,ARR
-Phecda,B,50,North Shroud,ARR
-Girtab,A,50,North Shroud,ARR
-Thousand-cast Theda,S,50,North Shroud,ARR
-Naul,B,50,Coerthas Central Highlands,ARR
-Marraco,A,50,Coerthas Central Highlands,ARR
-Safat,S,50,Coerthas Central Highlands,ARR
-Leech King,B,50,Mor Dhona,ARR
-Kurrea,A,50,Mor Dhona,ARR
-Agrippa the Mighty,S,50,Mor Dhona,ARR
-Vuokho,B,50,Outer La Noscea,ARR
-Cornu,A,50,Outer La Noscea,ARR
-Chernobog,S,50,Outer La Noscea,ARR
-Alteci,B,60,Coerthas Western Highlands,HW
-Kreutzet,B,60,Coerthas Western Highlands,HW
-Mirka,A,60,Coerthas Western Highlands,HW
-Lyuba,A,60,Coerthas Western Highlands,HW
-Kaiser Behemoth,S,60,Coerthas Western Highlands,HW
-Gnath Cometdrone,B,60,The Dravanian Forelands,HW
-Thextera,B,60,The Dravanian Forelands,HW
-Pylraster,A,60,The Dravanian Forelands,HW
-Lord of the Wyverns,A,60,The Dravanian Forelands,HW
-Senmurv,S,60,The Dravanian Forelands,HW
-Pterygotus,B,60,The Dravanian Hinterlands,HW
-False Gigantopithecus,B,60,The Dravanian Hinterlands,HW
-Slipkinx Steeljoints,A,60,The Dravanian Hinterlands,HW
-Stolas,A,60,The Dravanian Hinterlands,HW
-The Pale Rider,S,60,The Dravanian Hinterlands,HW
-Scitalis,B,60,The Churning Mists,HW
-The Scarecrow,B,60,The Churning Mists,HW
-Bune,A,60,The Churning Mists,HW
-Agathos,A,60,The Churning Mists,HW
-Gandarewa,S,60,The Churning Mists,HW
-Squonk,B,60,The Sea of Clouds,HW
-Sanu Vali of Dancing Wings,B,60,The Sea of Clouds,HW
-Enkelados,A,60,The Sea of Clouds,HW
-Sisiutl,A,60,The Sea of Clouds,HW
-Bird of Paradise,S,60,The Sea of Clouds,HW
-Lycidas,B,60,Azys Lla,HW
-Omni,B,60,Azys Lla,HW
-Campacti,A,60,Azys Lla,HW
-Stench Blossom,A,60,Azys Lla,HW
-Leucrotta,S,60,Azys Lla,HW
-Shadow-dweller Yamini,B,70,The Fringes,StB
-Ouzelum,B,70,The Fringes,StB
-Orcus,A,70,The Fringes,StB
-Erle,A,70,The Fringes,StB
-Udumbara,S,70,The Fringes,StB
-Gauki Strongblade,B,70,The Ruby Sea,StB
-Guhuo Niao,B,70,The Ruby Sea,StB
-Funa Yurei,A,70,The Ruby Sea,StB
-Oni Yumemi,A,70,The Ruby Sea,StB
-Okina,S,70,The Ruby Sea,StB
-Deidar,B,70,Yanxia,StB
-Gyorai Quickstrike,B,70,Yanxia,StB
-Gajasura,A,70,Yanxia,StB
-Angada,A,70,Yanxia,StB
-Gamma,S,70,Yanxia,StB
-Gwas-y-neidr,B,70,The Peaks,StB
-Buccaboo,B,70,The Peaks,StB
-Vochstein,A,70,The Peaks,StB
-Aqrabuamelu,A,70,The Peaks,StB
-Bone Crawler,S,70,The Peaks,StB
-Manes,B,70,The Lochs,StB
-Kiwa,B,70,The Lochs,StB
-Mahisha,A,70,The Lochs,StB
-Luminare,A,70,The Lochs,StB
-Salt and Light,S,70,The Lochs,StB
-Kurma,B,70,The Azim Steppe,StB
-Aswang,B,70,The Azim Steppe,StB
-Girimekhala,A,70,The Azim Steppe,StB
-Sum,A,70,The Azim Steppe,StB
-Orghana,S,70,The Azim Steppe,StB
-La Velue,B,80,Lakeland,ShB
-Itzpapalotl,B,80,Lakeland,ShB
-Nuckelavee,A,80,Lakeland,ShB
-Nariphon,A,80,Lakeland,ShB
-Tyger,S,80,Lakeland,ShB
-Coquecigrue,B,80,Kholusia,ShB
-Indomitable,B,80,Kholusia,ShB
-Li'l Murderer,A,80,Kholusia,ShB
-Huracan,A,80,Kholusia,ShB
-Forgiven Pedantry,S,80,Kholusia,ShB
-Worm of the Well,B,80,Amh Araeng,ShB
-Juggler Hecatomb,B,80,Amh Araeng,ShB
-Maliktender,A,80,Amh Araeng,ShB
-Sugaar,A,80,Amh Araeng,ShB
-Tarchia,S,80,Amh Araeng,ShB
-Domovoi,B,80,Il Mheg,ShB
-Vulpangue,B,80,Il Mheg,ShB
-The Mudman,A,80,Il Mheg,ShB
-O Poorest Pauldia,A,80,Il Mheg,ShB
-Aglaope,S,80,Il Mheg,ShB
-Mindmaker,B,80,The Rak'tika Greatwood,ShB
-Pachamama,B,80,The Rak'tika Greatwood,ShB
-Supay,A,80,The Rak'tika Greatwood,ShB
-Grassman,A,80,The Rak'tika Greatwood,ShB
-Ixtab,S,80,The Rak'tika Greatwood,ShB
-Gilshs Aath Swiftclaw,B,80,The Tempest,ShB
-Deacon,B,80,The Tempest,ShB
-Rusalka,A,80,The Tempest,ShB
-Baal,A,80,The Tempest,ShB
-Gunitt,S,80,The Tempest,ShB
-Green Archon,B,90,Labyrinthos,EW
-Ü-u-ü-u,B,90,Labyrinthos,EW
-Hulder,A,90,Labyrinthos,EW
-Storsie,A,90,Labyrinthos,EW
-Burfurlur the Canny,S,90,Labyrinthos,EW
-Vajrakumara,B,90,Thavnair,EW
-Iravati,B,90,Thavnair,EW
-Yilan,A,90,Thavnair,EW
-Sugriva,A,90,Thavnair,EW
-Sphatika,S,90,Thavnair,EW
-Warmonger,B,90,Garlemald,EW
-Emperor's Rose,B,90,Garlemald,EW
-Minerva,A,90,Garlemald,EW
-Aegeiros,A,90,Garlemald,EW
-Armstrong,S,90,Garlemald,EW
-Daphnia Magna,B,90,Mare Lamentorum,EW
-Genesis Rock,B,90,Mare Lamentorum,EW
-Mousse Princess,A,90,Mare Lamentorum,EW
-Lunatender Queen,A,90,Mare Lamentorum,EW
-Ruminator,S,90,Mare Lamentorum,EW
-Level Cheater,B,90,Ultima Thule,EW
-Oskh Rhei,B,90,Ultima Thule,EW
-Arch-Eta,A,90,Ultima Thule,EW
-Fan Ail,A,90,Ultima Thule,EW
-Narrow-rift,S,90,Ultima Thule,EW
-Yumcax,B,90,Elpis,EW
-Shockmaw,B,90,Elpis,EW
-Petalodus,A,90,Elpis,EW
-Gurangatch,A,90,Elpis,EW
-Ophioneus,S,90,Elpis,EW
-Mad Maguey,B,100,Urqopacha,DT
-Chupacabra,B,100,Urqopacha,DT
-Queen Hawk,A,100,Urqopacha,DT
-Nechuciho,A,100,Urqopacha,DT
-Kirlirger the Abhorrent,S,100,Urqopacha,DT
-The Slammer,B,100,Kozama'uka,DT
-Go'ozoabek'be,B,100,Kozama'uka,DT
-The Raintriller,A,100,Kozama'uka,DT
-Pkuucha,A,100,Kozama'uka,DT
-Ihnuxokiy,S,100,Kozama'uka,DT
-Leafscourge Hadoll Ja,B,100,Yak T'el,DT
-Xty'iinbek,B,100,Yak T'el,DT
-Rrax Yity'a,A,100,Yak T'el,DT
-Starcrier,A,100,Yak T'el,DT
-Neyoozoteel,S,100,Yak T'el,DT
-Nopalitender Fabuloso,B,100,Shaaloani,DT
-Uktena,B,100,Shaaloani,DT
-Yehehetoaua'pyo,A,100,Shaaloani,DT
-Keheniheyamewi,A,100,Shaaloani,DT
-Sansheya,S,100,Shaaloani,DT
-Gallowsbeak,B,100,Heritage Found,DT
-Gargant,B,100,Heritage Found,DT
-Heshuala,A,100,Heritage Found,DT
-Urna Variabilis,A,100,Heritage Found,DT
-Atticus the Primogenitor,S,100,Heritage Found,DT
-Jewel Bearer,B,100,Living Memory,DT
-13th Child,B,100,Living Memory,DT
-Sally the Sweeper,A,100,Living Memory,DT
-Cat's Eye,A,100,Living Memory,DT
-The Forecaster,S,100,Living Memory,DT
+BNpcNameId,Name,Rank,Location,Level,Expansion
+2928,Skogs Fru,B,Middle La Noscea,50,ARR
+2945,Vogaal Ja,A,Middle La Noscea,50,ARR
+2962,Croque-Mitaine,S,Middle La Noscea,50,ARR
+2929,Barbastelle,B,Lower La Noscea,50,ARR
+2946,Unktehi,A,Lower La Noscea,50,ARR
+2963,Croakadile,S,Lower La Noscea,50,ARR
+2930,Bloody Mary,B,Eastern La Noscea,50,ARR
+2947,Hellsclaw,A,Eastern La Noscea,50,ARR
+2964,The Garlok,S,Eastern La Noscea,50,ARR
+2931,Dark Helmet,B,Western La Noscea,50,ARR
+2948,Nahn,A,Western La Noscea,50,ARR
+2965,Bonnacon,S,Western La Noscea,50,ARR
+2932,Myradrosh,B,Upper La Noscea,50,ARR
+2949,Marberry,A,Upper La Noscea,50,ARR
+2966,Nandi,S,Upper La Noscea,50,ARR
+2923,Sewer Syrup,B,Western Thanalan,50,ARR
+2940,Alectryon,A,Western Thanalan,50,ARR
+2957,Zona Seeker,S,Western Thanalan,50,ARR
+2924,Ovjang,B,Central Thanalan,50,ARR
+2941,Sabotender Bailarina,A,Central Thanalan,50,ARR
+2958,Brontes,S,Central Thanalan,50,ARR
+2925,Gatling,B,Eastern Thanalan,50,ARR
+2942,Maahes,A,Eastern Thanalan,50,ARR
+2959,Lampalagua,S,Eastern Thanalan,50,ARR
+2926,Albin the Ashen,B,Southern Thanalan,50,ARR
+2943,Zanig'oh,A,Southern Thanalan,50,ARR
+2960,Nunyunuwi,S,Southern Thanalan,50,ARR
+2927,Flame Sergeant Dalvag,B,Northern Thanalan,50,ARR
+2944,Dalvag's Final Flame,A,Northern Thanalan,50,ARR
+2961,Minhocao,S,Northern Thanalan,50,ARR
+2919,White Joker,B,Central Shroud,50,ARR
+2936,Forneus,A,Central Shroud,50,ARR
+2953,Laideronnette,S,Central Shroud,50,ARR
+2920,Stinging Sophie,B,East Shroud,50,ARR
+2937,Melt,A,East Shroud,50,ARR
+2954,Wulgaru,S,East Shroud,50,ARR
+2921,Monarch Ogrefly,B,South Shroud,50,ARR
+2938,Ghede Ti Malice,A,South Shroud,50,ARR
+2955,Mindflayer,S,South Shroud,50,ARR
+2922,Phecda,B,North Shroud,50,ARR
+2939,Girtab,A,North Shroud,50,ARR
+2956,Thousand-cast Theda,S,North Shroud,50,ARR
+2934,Naul,B,Coerthas Central Highlands,50,ARR
+2951,Marraco,A,Coerthas Central Highlands,50,ARR
+2968,Safat,S,Coerthas Central Highlands,50,ARR
+2935,Leech King,B,Mor Dhona,50,ARR
+2952,Kurrea,A,Mor Dhona,50,ARR
+2969,Agrippa the Mighty,S,Mor Dhona,50,ARR
+2933,Vuokho,B,Outer La Noscea,50,ARR
+2950,Cornu,A,Outer La Noscea,50,ARR
+2967,Chernobog,S,Outer La Noscea,50,ARR
+4350,Alteci,B,Coerthas Western Highlands,60,HW
+4351,Kreutzet,B,Coerthas Western Highlands,60,HW
+4362,Mirka,A,Coerthas Western Highlands,60,HW
+4363,Lyuba,A,Coerthas Western Highlands,60,HW
+4374,Kaiser Behemoth,S,Coerthas Western Highlands,60,HW
+4352,Gnath Cometdrone,B,The Dravanian Forelands,60,HW
+4353,Thextera,B,The Dravanian Forelands,60,HW
+4364,Pylraster,A,The Dravanian Forelands,60,HW
+4365,Lord of the Wyverns,A,The Dravanian Forelands,60,HW
+4375,Senmurv,S,The Dravanian Forelands,60,HW
+4354,Pterygotus,B,The Dravanian Hinterlands,60,HW
+4355,False Gigantopithecus,B,The Dravanian Hinterlands,60,HW
+4366,Slipkinx Steeljoints,A,The Dravanian Hinterlands,60,HW
+4367,Stolas,A,The Dravanian Hinterlands,60,HW
+4376,The Pale Rider,S,The Dravanian Hinterlands,60,HW
+4356,Scitalis,B,The Churning Mists,60,HW
+4357,The Scarecrow,B,The Churning Mists,60,HW
+4368,Bune,A,The Churning Mists,60,HW
+4369,Agathos,A,The Churning Mists,60,HW
+4377,Gandarewa,S,The Churning Mists,60,HW
+4358,Squonk,B,The Sea of Clouds,60,HW
+4359,Sanu Vali of Dancing Wings,B,The Sea of Clouds,60,HW
+4370,Enkelados,A,The Sea of Clouds,60,HW
+4371,Sisiutl,A,The Sea of Clouds,60,HW
+4378,Bird of Paradise,S,The Sea of Clouds,60,HW
+4360,Lycidas,B,Azys Lla,60,HW
+4361,Omni,B,Azys Lla,60,HW
+4372,Campacti,A,Azys Lla,60,HW
+4373,Stench Blossom,A,Azys Lla,60,HW
+4380,Leucrotta,S,Azys Lla,60,HW
+6008,Shadow-dweller Yamini,B,The Fringes,70,StB
+6009,Ouzelum,B,The Fringes,70,StB
+5990,Orcus,A,The Fringes,70,StB
+5991,Erle,A,The Fringes,70,StB
+5987,Udumbara,S,The Fringes,70,StB
+6002,Gauki Strongblade,B,The Ruby Sea,70,StB
+6003,Guhuo Niao,B,The Ruby Sea,70,StB
+5996,Funa Yurei,A,The Ruby Sea,70,StB
+5997,Oni Yumemi,A,The Ruby Sea,70,StB
+5984,Okina,S,The Ruby Sea,70,StB
+6004,Deidar,B,Yanxia,70,StB
+6005,Gyorai Quickstrike,B,Yanxia,70,StB
+5998,Gajasura,A,Yanxia,70,StB
+5999,Angada,A,Yanxia,70,StB
+5985,Gamma,S,Yanxia,70,StB
+6010,Gwas-y-neidr,B,The Peaks,70,StB
+6011,Buccaboo,B,The Peaks,70,StB
+5992,Vochstein,A,The Peaks,70,StB
+5993,Aqrabuamelu,A,The Peaks,70,StB
+5988,Bone Crawler,S,The Peaks,70,StB
+6012,Manes,B,The Lochs,70,StB
+6013,Kiwa,B,The Lochs,70,StB
+5994,Mahisha,A,The Lochs,70,StB
+5995,Luminare,A,The Lochs,70,StB
+5989,Salt and Light,S,The Lochs,70,StB
+6006,Kurma,B,The Azim Steppe,70,StB
+6007,Aswang,B,The Azim Steppe,70,StB
+6000,Girimekhala,A,The Azim Steppe,70,StB
+6001,Sum,A,The Azim Steppe,70,StB
+5986,Orghana,S,The Azim Steppe,70,StB
+8908,La Velue,B,Lakeland,80,ShB
+8909,Itzpapalotl,B,Lakeland,80,ShB
+8906,Nuckelavee,A,Lakeland,80,ShB
+8907,Nariphon,A,Lakeland,80,ShB
+8905,Tyger,S,Lakeland,80,ShB
+8913,Coquecigrue,B,Kholusia,80,ShB
+8914,Indomitable,B,Kholusia,80,ShB
+8911,Li'l Murderer,A,Kholusia,80,ShB
+8912,Huracan,A,Kholusia,80,ShB
+8910,Forgiven Pedantry,S,Kholusia,80,ShB
+8903,Worm of the Well,B,Amh Araeng,80,ShB
+8904,Juggler Hecatomb,B,Amh Araeng,80,ShB
+8901,Maliktender,A,Amh Araeng,80,ShB
+8902,Sugaar,A,Amh Araeng,80,ShB
+8900,Tarchia,S,Amh Araeng,80,ShB
+8656,Domovoi,B,Il Mheg,80,ShB
+8657,Vulpangue,B,Il Mheg,80,ShB
+8654,The Mudman,A,Il Mheg,80,ShB
+8655,O Poorest Pauldia,A,Il Mheg,80,ShB
+8653,Aglaope,S,Il Mheg,80,ShB
+8893,Mindmaker,B,The Rak'tika Greatwood,80,ShB
+8894,Pachamama,B,The Rak'tika Greatwood,80,ShB
+8891,Supay,A,The Rak'tika Greatwood,80,ShB
+8892,Grassman,A,The Rak'tika Greatwood,80,ShB
+8890,Ixtab,S,The Rak'tika Greatwood,80,ShB
+8898,Gilshs Aath Swiftclaw,B,The Tempest,80,ShB
+8899,Deacon,B,The Tempest,80,ShB
+8896,Rusalka,A,The Tempest,80,ShB
+8897,Baal,A,The Tempest,80,ShB
+8895,Gunitt,S,The Tempest,80,ShB
+10635,Green Archon,B,Labyrinthos,90,EW
+10636,Ü-u-ü-u,B,Labyrinthos,90,EW
+10624,Hulder,A,Labyrinthos,90,EW
+10623,Storsie,A,Labyrinthos,90,EW
+10617,Burfurlur the Canny,S,Labyrinthos,90,EW
+10637,Vajrakumara,B,Thavnair,90,EW
+10638,Iravati,B,Thavnair,90,EW
+10625,Yilan,A,Thavnair,90,EW
+10626,Sugriva,A,Thavnair,90,EW
+10618,Sphatika,S,Thavnair,90,EW
+10639,Warmonger,B,Garlemald,90,EW
+10640,Emperor's Rose,B,Garlemald,90,EW
+10627,Minerva,A,Garlemald,90,EW
+10628,Aegeiros,A,Garlemald,90,EW
+10619,Armstrong,S,Garlemald,90,EW
+10641,Daphnia Magna,B,Mare Lamentorum,90,EW
+10642,Genesis Rock,B,Mare Lamentorum,90,EW
+10630,Mousse Princess,A,Mare Lamentorum,90,EW
+10629,Lunatender Queen,A,Mare Lamentorum,90,EW
+10620,Ruminator,S,Mare Lamentorum,90,EW
+10645,Level Cheater,B,Ultima Thule,90,EW
+10646,Oskh Rhei,B,Ultima Thule,90,EW
+10634,Arch-Eta,A,Ultima Thule,90,EW
+10633,Fan Ail,A,Ultima Thule,90,EW
+10622,Narrow-rift,S,Ultima Thule,90,EW
+10643,Yumcax,B,Elpis,90,EW
+10644,Shockmaw,B,Elpis,90,EW
+10632,Petalodus,A,Elpis,90,EW
+10631,Gurangatch,A,Elpis,90,EW
+10621,Ophioneus,S,Elpis,90,EW
+13144,Mad Maguey,B,Urqopacha,100,DT
+13145,Chupacabra,B,Urqopacha,100,DT
+13361,Queen Hawk,A,Urqopacha,100,DT
+13362,Nechuciho,A,Urqopacha,100,DT
+13360,Kirlirger the Abhorrent,S,Urqopacha,100,DT
+13146,The Slammer,B,Kozama'uka,100,DT
+13147,Go'ozoabek'be,B,Kozama'uka,100,DT
+13442,The Raintriller,A,Kozama'uka,100,DT
+13443,Pkuucha,A,Kozama'uka,100,DT
+13444,Ihnuxokiy,S,Kozama'uka,100,DT
+13148,Leafscourge Hadoll Ja,B,Yak T'el,100,DT
+13149,Xty'iinbek,B,Yak T'el,100,DT
+12753,Rrax Yity'a,A,Yak T'el,100,DT
+12692,Starcrier,A,Yak T'el,100,DT
+12754,Neyoozoteel,S,Yak T'el,100,DT
+13150,Nopalitender Fabuloso,B,Shaaloani,100,DT
+13151,Uktena,B,Shaaloani,100,DT
+13400,Yehehetoaua'pyo,A,Shaaloani,100,DT
+13401,Keheniheyamewi,A,Shaaloani,100,DT
+13399,Sansheya,S,Shaaloani,100,DT
+13152,Gallowsbeak,B,Heritage Found,100,DT
+13153,Gargant,B,Heritage Found,100,DT
+13157,Heshuala,A,Heritage Found,100,DT
+13158,Urna Variabilis,A,Heritage Found,100,DT
+13156,Atticus the Primogenitor,S,Heritage Found,100,DT
+13154,Jewel Bearer,B,Living Memory,100,DT
+13155,13th Child,B,Living Memory,100,DT
+13435,Sally the Sweeper,A,Living Memory,100,DT
+13436,Cat's Eye,A,Living Memory,100,DT
+13437,The Forecaster,S,Living Memory,100,DT

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -161,7 +161,7 @@ def load_all_fish():
 _HUNT_EXPANSIONS: dict[str, tuple[str, int]] = {
     "0": ("ARR", 50),
     "1": ("HW", 60),
-    "2": ("SB", 70),
+    "2": ("StB", 70),
     "3": ("ShB", 80),
     "4": ("EW", 90),
     "5": ("DT", 100),

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -174,12 +174,6 @@ _HUNT_RANK_LABELS = {"1": "B", "2": "A", "3": "S"}
 def _build_nm_territory_map(
     territory_type: dict[str, dict[str, str]],
 ) -> dict[str, tuple[str, str]]:
-    """Return {NMTerritory row id -> (PlaceName id, ExVersion)} from TerritoryType rows.
-
-    Some open-world zones have multiple TerritoryType rows sharing the same
-    NotoriousMonsterTerritory (e.g. weather/phase variants of the same zone).
-    Only the first hit is kept so each hunt territory maps to a single zone name.
-    """
     result: dict[str, tuple[str, str]] = {}
     for tt in territory_type.values():
         nm_terr_id = tt.get("NotoriousMonsterTerritory", "0")
@@ -199,17 +193,23 @@ def _build_nm_territory_map(
 
 _HUNT_NAME_IGNORE = { "of", "the", "and" }
 
-_HUNT_NAME_SKIP: dict[str] = {
+_HUNT_NAME_SKIP: set[str] = {
     "Thousand-cast Theda",
     "Shadow-dweller Yamini",
     "Narrow-rift",
     "Gwas-y-neidr"
 }
 
+_HUNT_NAME_MANUAL_FIX: dict[str, str] = {
+    "Croque-mitaine": "Croque-Mitaine",
+}
+
 
 def _normalize_hunt_name(name: str) -> str:
     if name in _HUNT_NAME_SKIP:
         return name
+    elif name in _HUNT_NAME_MANUAL_FIX:
+        return _HUNT_NAME_MANUAL_FIX[name]
 
     words = name.split(" ")
     result: list[str] = []
@@ -265,7 +265,6 @@ def scrape_hunts() -> list[dict[str, str]]:
     bnpc_name          = datamining_csv("BNpcName")
     # Relevant column: Name (zone name )
     place_name         = datamining_csv("PlaceName")
-
     # NMTerritory id -> (PlaceName id, ExVersion string)
     nm_terr_to_zone = _build_nm_territory_map(territory_type)
 

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -197,6 +197,32 @@ def _build_nm_territory_map(
     return result
 
 
+_HUNT_NAME_IGNORE = { "of", "the", "and" }
+
+_HUNT_NAME_SKIP: dict[str] = {
+    "Thousand-cast Theda",
+    "Shadow-dweller Yamini",
+    "Narrow-rift",
+    "Gwas-y-neidr"
+}
+
+
+def _normalize_hunt_name(name: str) -> str:
+    if name in _HUNT_NAME_SKIP:
+        return name
+
+    words = name.split(" ")
+    result: list[str] = []
+    
+    for i, word in enumerate(words):
+        if i > 0 and word.lower() in _HUNT_NAME_IGNORE:
+            result.append(word.lower())
+        else:
+            result.append(word[0].upper() + word[1:])
+            
+    return " ".join(result)
+
+
 def _write_hunts_csv(rows: list[dict[str, str]]) -> None:
     out_path = os.path.join(os.path.dirname(__file__), "hunts.csv")
     with open(out_path, "w", newline="", encoding="utf-8") as h:
@@ -306,6 +332,8 @@ def scrape_hunts() -> list[dict[str, str]]:
             
             if not mob_name:
                 continue
+
+            mob_name = _normalize_hunt_name(mob_name)
 
             rows.append({
                 "Name":      mob_name,

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -7,7 +7,6 @@ import functools
 import json
 import math
 import os
-import re
 from typing import Literal
 
 import bs4
@@ -156,6 +155,186 @@ def load_all_fish():
     with open(data_path('fish.json'), 'r', newline='') as h:
         all_fish = json.load(h)
     return all_fish
+
+
+# Mapping of TerritoryType.ExVersion -> (expansion tag, capstone level)
+_HUNT_EXPANSIONS: dict[str, tuple[str, int]] = {
+    "0": ("ARR", 50),
+    "1": ("HW", 60),
+    "2": ("SB", 70),
+    "3": ("ShB", 80),
+    "4": ("EW", 90),
+    "5": ("DT", 100),
+}
+
+# NotoriousMonster.Rank values: 1 = B, 2 = A, 3 = S
+_HUNT_RANK_LABELS = {"1": "B", "2": "A", "3": "S"}
+
+
+def _build_nm_territory_map(
+    territory_type: dict[str, dict[str, str]],
+) -> dict[str, tuple[str, str]]:
+    """Return {NMTerritory row id -> (PlaceName id, ExVersion)} from TerritoryType rows.
+
+    Some open-world zones have multiple TerritoryType rows sharing the same
+    NotoriousMonsterTerritory (e.g. weather/phase variants of the same zone).
+    Only the first hit is kept so each hunt territory maps to a single zone name.
+    """
+    result: dict[str, tuple[str, str]] = {}
+    for tt in territory_type.values():
+        nm_terr_id = tt.get("NotoriousMonsterTerritory", "0")
+        
+        if not nm_terr_id or nm_terr_id == "0" or nm_terr_id in result:
+            continue
+        
+        place = tt.get("PlaceName", "0")
+        
+        if place == "0":
+            continue
+        
+        result[nm_terr_id] = (place, tt.get("ExVersion", "0"))
+        
+    return result
+
+
+def _write_hunts_csv(rows: list[dict[str, str]]) -> None:
+    out_path = os.path.join(os.path.dirname(__file__), "hunts.csv")
+    with open(out_path, "w", newline="", encoding="utf-8") as h:
+        writer = csv.DictWriter(h, fieldnames=["Name", "Rank", "Level", "Location", "Expansion"])
+        writer.writeheader()
+        writer.writerows(rows)
+    by_rank = {r: sum(1 for row in rows if row["Rank"] == r) for r in ("B", "A", "S")}
+    print(f"Wrote {len(rows)} hunt marks to {out_path} (by rank: {by_rank})")
+
+
+def scrape_hunts() -> list[dict[str, str]]:
+    """Build Hunt Mark (Notorious Monster) locations from datamining CSVs.
+
+    Writes ``hunts.csv`` alongside ``duties.csv``/``fates.csv`` and returns the
+    rows for inspection. Columns: Name, Rank, Level, Location, Expansion.
+
+    Sheet relationships used here:
+      TerritoryType             - one row per playable zone; links to NMTerritory + PlaceName + ExVersion
+      NotoriousMonster          - one row per hunt mark; has Rank (1/2/3) and BNpcName id
+      NotoriousMonsterTerritory - groups up to 10 NM ids per open-world zone
+      BNpcName                  - resolves BNpcName id -> display name (Singular column)
+      PlaceName                 - resolves PlaceName id -> human-readable zone name (Name column)
+
+    Lookup chain per hunt mark:
+      TerritoryType.NotoriousMonsterTerritory  ->  NotoriousMonsterTerritory row
+      NotoriousMonsterTerritory.NotoriousMonsters[i]  ->  NotoriousMonster row
+      NotoriousMonster.BNpcName  ->  BNpcName.Singular  (mob display name)
+      TerritoryType.PlaceName  ->  PlaceName.Name  (zone display name)
+      TerritoryType.ExVersion  ->  expansion tag + capstone level
+    """
+    print("Building hunts.csv from datamining CSVs")
+
+    # Relevant columns: PlaceName, ExVersion, NotoriousMonsterTerritory
+    territory_type     = datamining_csv("TerritoryType")
+    # Relevant columns: BNpcName (id), Rank (1=B,2=A,3=S)
+    notorious_monster  = datamining_csv("NotoriousMonster")
+    # Columns: NotoriousMonsters[0..9] (NM row ids)
+    nm_territory       = datamining_csv("NotoriousMonsterTerritory")
+    # Relevant column: Singular (mob name)
+    bnpc_name          = datamining_csv("BNpcName")
+    # Relevant column: Name (zone name )
+    place_name         = datamining_csv("PlaceName")
+
+    # NMTerritory id -> (PlaceName id, ExVersion string)
+    nm_terr_to_zone = _build_nm_territory_map(territory_type)
+
+    rows: list[dict[str, str]] = []
+    # Dedup guard: the same NM can appear in multiple TerritoryType rows for the same zone.
+    seen_hunts: set[tuple[str, str, str]] = set()  # (bnpc_id, place_id, rank_label)
+
+    for terr_id, terr in nm_territory.items():
+        # Skip NMTerritory rows that have no matching open-world zone (e.g. unused rows)
+        zone = nm_terr_to_zone.get(terr_id)
+        
+        if not zone:
+            continue
+        
+        place_id, ex_version = zone
+
+        expansion_info = _HUNT_EXPANSIONS.get(ex_version)
+        
+        # Skip new expansion data
+        if expansion_info is None:
+            continue
+        
+        expansion_tag, level = expansion_info
+
+        # Resolve the zone's display name from PlaceName
+        zone_name = place_name.get(place_id, {}).get("Name", "")
+        
+        if not zone_name:
+            continue
+
+        # Each territory row has up to 10 NM slots
+        for i in range(10):
+            slot = f"NotoriousMonsters[{i}]"
+            nm_id = terr.get(slot, "0")
+            
+            if not nm_id or nm_id == "0":
+                continue
+
+            nm = notorious_monster.get(nm_id)
+            
+            if not nm:
+                continue
+
+            rank_label = _HUNT_RANK_LABELS.get(nm.get("Rank", "0"))
+            
+            if rank_label is None:
+                continue
+
+            # BNpcName is the id used to look up the display name
+            bnpc_id = nm.get("BNpcName", "0")
+            
+            if bnpc_id == "0":
+                continue
+
+            hunt_key = (bnpc_id, place_id, rank_label)
+            
+            if hunt_key in seen_hunts:
+                continue
+            
+            seen_hunts.add(hunt_key)
+
+            # BNpcName.Singular is the in-game name (inconsistent formatting)
+            mob_name = bnpc_name.get(bnpc_id, {}).get("Singular", "")
+            
+            if not mob_name:
+                continue
+
+            rows.append({
+                "Name":      mob_name,
+                "Rank":      rank_label,
+                "Level":     level,
+                "Location":  zone_name,
+                "Expansion": expansion_tag,
+            })
+
+    # SS hunts (e.g. Ker, Ker Shroud) spawn in multiple zones
+    # Just filter out any entries with multiple locations
+    zone_count_by_name: dict[str, int] = {}
+    for row in rows:
+        zone_count_by_name[row["Name"]] = zone_count_by_name.get(row["Name"], 0) + 1
+        
+    elite_marks = {name for name, count in zone_count_by_name.items() if count > 1}
+    
+    if elite_marks:
+        print(f"Filtering out {len(elite_marks)} SS hunts: {sorted(elite_marks)}")
+        filtered: list[dict[str, str]] = []
+        
+        for row in rows:
+            if row["Name"] not in elite_marks:
+                filtered.append(row)
+                
+        rows = filtered
+
+    _write_hunts_csv(rows)
+    return rows
 
 # def find_fishing_spots() -> None:
 #     baseurl = "https://ffxiv.consolegameswiki.com/mediawiki/api.php?action=ask&query=[[Category:Fishing_log]]|?Gives resource|?Has fishing log level|?Located in|?Bait used|sort=Has fishing log level|offset={0}&format=json&api_version=3"
@@ -715,6 +894,7 @@ def sort_fish():
 
 
 if __name__ == "__main__":
+    scrape_hunts()
     scrape_teamcraft()
     tribal_fish()
     apply_bait()

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -226,7 +226,7 @@ def _normalize_hunt_name(name: str) -> str:
 def _write_hunts_csv(rows: list[dict[str, str]]) -> None:
     out_path = os.path.join(os.path.dirname(__file__), "hunts.csv")
     with open(out_path, "w", newline="", encoding="utf-8") as h:
-        writer = csv.DictWriter(h, fieldnames=["Name", "Rank", "Level", "Location", "Expansion"])
+        writer = csv.DictWriter(h, fieldnames=["BNpcNameId", "Name", "Rank", "Location", "Level", "Expansion"])
         writer.writeheader()
         writer.writerows(rows)
     by_rank = {r: sum(1 for row in rows if row["Rank"] == r) for r in ("B", "A", "S")}
@@ -314,12 +314,12 @@ def scrape_hunts() -> list[dict[str, str]]:
                 continue
 
             # BNpcName is the id used to look up the display name
-            bnpc_id = nm.get("BNpcName", "0")
+            bnpc_name_id = nm.get("BNpcName", "0")
             
-            if bnpc_id == "0":
+            if bnpc_name_id == "0":
                 continue
 
-            hunt_key = (bnpc_id, place_id, rank_label)
+            hunt_key = (bnpc_name_id, place_id, rank_label)
             
             if hunt_key in seen_hunts:
                 continue
@@ -327,7 +327,7 @@ def scrape_hunts() -> list[dict[str, str]]:
             seen_hunts.add(hunt_key)
 
             # BNpcName.Singular is the in-game name (inconsistent formatting)
-            mob_name = bnpc_name.get(bnpc_id, {}).get("Singular", "")
+            mob_name = bnpc_name.get(bnpc_name_id, {}).get("Singular", "")
             
             if not mob_name:
                 continue
@@ -335,10 +335,11 @@ def scrape_hunts() -> list[dict[str, str]]:
             mob_name = _normalize_hunt_name(mob_name)
 
             rows.append({
+                "BNpcNameId": bnpc_name_id,
                 "Name":      mob_name,
                 "Rank":      rank_label,
-                "Level":     level,
                 "Location":  zone_name,
+                "Level":     level,
                 "Expansion": expansion_tag,
             })
 

--- a/src/hooks/wiki_scraper.py
+++ b/src/hooks/wiki_scraper.py
@@ -225,19 +225,18 @@ def _normalize_hunt_name(name: str) -> str:
 
 def _write_hunts_csv(rows: list[dict[str, str]]) -> None:
     out_path = os.path.join(os.path.dirname(__file__), "hunts.csv")
+    
     with open(out_path, "w", newline="", encoding="utf-8") as h:
         writer = csv.DictWriter(h, fieldnames=["BNpcNameId", "Name", "Rank", "Location", "Level", "Expansion"])
         writer.writeheader()
         writer.writerows(rows)
+        
     by_rank = {r: sum(1 for row in rows if row["Rank"] == r) for r in ("B", "A", "S")}
     print(f"Wrote {len(rows)} hunt marks to {out_path} (by rank: {by_rank})")
 
 
 def scrape_hunts() -> list[dict[str, str]]:
-    """Build Hunt Mark (Notorious Monster) locations from datamining CSVs.
-
-    Writes ``hunts.csv`` alongside ``duties.csv``/``fates.csv`` and returns the
-    rows for inspection. Columns: Name, Rank, Level, Location, Expansion.
+    """Build Hunt (Notorious Monster) locations from datamining CSVs.
 
     Sheet relationships used here:
       TerritoryType             - one row per playable zone; links to NMTerritory + PlaceName + ExVersion


### PR DESCRIPTION
The plan is to allow users to pick their set of ranks to include within the huntsanity settings.
A "slider" from B to S wouldn't work in case a user does not want to deal with A ranks. Which would make sense, as A ranks are likely the hardest enemies to clear. Low level ones are just killed on sight and not shared with anyone.

