### PR TITLE
Adjust boss goal defaults

### DIFF
--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -423,8 +423,9 @@ def after_options_defined(options: type[PerGameCommonOptions]) -> None:
     #  Here's an example on how to add your aliases to the generated goal
     # options.type_hints['goal'].aliases.update({"example": 0, "second_alias": 1})
     # options.type_hints['goal'].options.update({"example": 0, "second_alias": 1})  #for an alias to be valid it must also be in options
-
-    pass
+    from ..Locations import victory_names
+    
+    options.type_hints['goal'].default = victory_names.index("Defeat Necron")
 
 # Use this Hook if you want to add your Option to an Option group (existing or not)
 def before_option_groups_created(groups: dict[str, list[type[Option]]]) -> dict[str, list[type[Option]]]:

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -363,8 +363,9 @@ def after_options_defined(options: type[PerGameCommonOptions]) -> None:
     #  Here's an example on how to add your aliases to the generated goal
     # options.type_hints['goal'].aliases.update({"example": 0, "second_alias": 1})
     # options.type_hints['goal'].options.update({"example": 0, "second_alias": 1})  #for an alias to be valid it must also be in options
-
-    pass
+    from ..Locations import victory_names
+    
+    options.type_hints['goal'].default = victory_names.index("Defeat Necron")
 
 # Use this Hook if you want to add your Option to an Option group (existing or not)
 def before_option_groups_created(groups: dict[str, list[type[Option]]]) -> dict[str, list[type[Option]]]:

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -206,14 +206,14 @@ class BossKeyPieces(Range):
     Number of key pieces required to challenge the final boss (boss goal only).
 
     When set to 0, no key is required and the victory location is accessible on region and level alone.
-    When set to 1-10, that many key items are shuffled into the item pool
+    When set to 1-25, that many key items are shuffled into the item pool
     and must all be collected before the goal location is accessible.
     Has no effect when the goal is set to McGuffin Hunt (Collect Memories).
     """
     display_name = "Boss Key Pieces"
-    default = 0
+    default = 10
     range_start = 0
-    range_end = 10
+    range_end = 25
 
 class ForceJob(OptionSet):
     """

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -216,14 +216,14 @@ class BossKeyPieces(Range):
     Number of key pieces required to challenge the final boss (boss goal only).
 
     When set to 0, no key is required and the victory location is accessible on region and level alone.
-    When set to 1-10, that many key items are shuffled into the item pool
+    When set to 1-25, that many key items are shuffled into the item pool
     and must all be collected before the goal location is accessible.
     Has no effect when the goal is set to McGuffin Hunt (Collect Memories).
     """
     display_name = "Boss Key Pieces"
-    default = 0
+    default = 10
     range_start = 0
-    range_end = 10
+    range_end = 25
 
 class ForceJob(OptionSet):
     """

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -307,6 +307,10 @@ def before_create_items_all(item_config: dict[str, int|dict], world: World, mult
                 if goal_trial and goal_trial in all_location_names:
                     world._goal_trial = goal_trial
                     location_count -= 1
+                    event_name = f"{goal_duty_base_name} Cleared"
+                    item_id = world.item_name_to_id.get(event_name)
+                    trial_event = ManualItem(event_name, ItemClassification.progression, item_id, player)
+                    multiworld.get_location(goal_trial, player).place_locked_item(trial_event)
                     break
 
     level_cap = get_int_value(multiworld, player, "level_cap") or LevelCap.range_end
@@ -462,11 +466,6 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     if goal_duty_base_name and goal_trial:
         event_name = f"{goal_duty_base_name} Cleared"
         trial_location = multiworld.get_location(goal_trial, player)
-
-        # Put goal's "Cleared" item into it's trial location and require it for goal
-        item_id = world.item_name_to_id.get(event_name)
-        trial_event = ManualItem(event_name, ItemClassification.progression, item_id, player)
-        trial_location.place_locked_item(trial_event)
 
         def has_cleared_goal_trial(state: CollectionState) -> bool:
             return state.has(event_name, player)

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -333,6 +333,10 @@ def before_create_items_all(item_config: dict[str, int|dict], world: World, mult
                 if goal_trial and goal_trial in all_location_names:
                     world._goal_trial = goal_trial
                     location_count -= 1
+                    event_name = f"{goal_duty_base_name} Cleared"
+                    item_id = world.item_name_to_id.get(event_name)
+                    trial_event = ManualItem(event_name, ItemClassification.progression, item_id, player)
+                    multiworld.get_location(goal_trial, player).place_locked_item(trial_event)
                     break
 
     level_cap = get_int_value(multiworld, player, "level_cap") or LevelCap.range_end
@@ -504,11 +508,6 @@ def after_set_rules(world: World, multiworld: MultiWorld, player: int):
     if goal_duty_base_name and goal_trial:
         event_name = f"{goal_duty_base_name} Cleared"
         trial_location = multiworld.get_location(goal_trial, player)
-
-        # Put goal's "Cleared" item into it's trial location and require it for goal
-        item_id = world.item_name_to_id.get(event_name)
-        trial_event = ManualItem(event_name, ItemClassification.progression, item_id, player)
-        trial_location.place_locked_item(trial_event)
 
         def has_cleared_goal_trial(state: CollectionState) -> bool:
             return state.has(event_name, player)


### PR DESCRIPTION
My reason for making these changes:

1) In my opinion beating the last story boss counts way more as beating the game than randomly getting items that normally don't exist
2) It runs tests with boss goals in mind. That way I discovered that item and location amount was off by 1
3) It generates playthroughs that regularly hit end game content. With McGuffins you very often don't get to see the later half of the expansions. **This is extra important for playthroughs with excluded expansions.**
4) More key amounts just so people can have a similar goal to mcguffin hunt while also having a very clear final goal to finish the run

Originally part of https://github.com/silasary/APxiv/pull/44