### PR TITLE
In the event that a FATE name is too long for the fateReward window, …

### DIFF
--- a/ArchipelagoXIV/Hooks/Events.cs
+++ b/ArchipelagoXIV/Hooks/Events.cs
@@ -66,6 +66,11 @@ namespace ArchipelagoXIV.Hooks
 
             var loc = apState.MissingLocations.FirstOrDefault(f => f.Name.Equals(locName, StringComparison.OrdinalIgnoreCase));  // FATEsanity check
             loc ??= apState.MissingLocations.FirstOrDefault(f => f.Name.StartsWith(apState.territoryName + ": FATE #") && !f.Completed);  // FATE #N check
+            if (fateName.EndsWith("..."))
+            {
+                DalamudApi.Echo($"Too long: {locName}");
+                loc = apState.MissingLocations.FirstOrDefault(f => f.Name.StartsWith(fateName[..^3], StringComparison.OrdinalIgnoreCase)); // FATEsanity check, if name is too long
+            }
             if (loc == null)
             {
                 DalamudApi.PluginLog.Information($"Fate `{locName}` not in world or already completed");


### PR DESCRIPTION
Checks the name pre-"..."

There might be a better way to handle the if statement, since it will check this every single time, regardless if it was good. I thought about storing this in loc == null, and then doing a second if loc == null inside that if, but wasn't sure if that was more messy or not