### PR TITLE
Allow Logic.FromString to handle or statements

### DIFF
--- a/ArchipelagoXIV/Rando/Logic.cs
+++ b/ArchipelagoXIV/Rando/Logic.cs
@@ -23,7 +23,7 @@ namespace ArchipelagoXIV.Rando
             var rules = (from Match m in Regexes.itemRegex.Matches(requires)
                          select HasItem(m.Groups[0].Value)).ToArray();
             if (rules.Length != 0)
-                return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
+                return (state, asCurrentClass) => rules.Any(r => r(state, asCurrentClass));
             if (string.IsNullOrEmpty(requires))
                 return Always();
             DalamudApi.Echo($"Could not parse Requires string: {requires}");

--- a/ArchipelagoXIV/Rando/Logic.cs
+++ b/ArchipelagoXIV/Rando/Logic.cs
@@ -26,7 +26,7 @@ namespace ArchipelagoXIV.Rando
                 if(requires.Contains("| or |"))
                     return (state, asCurrentClass) => rules.Any(r => r(state, asCurrentClass));
                 else
-                return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
+                    return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
             if (string.IsNullOrEmpty(requires))
                 return Always();
             DalamudApi.Echo($"Could not parse Requires string: {requires}");

--- a/ArchipelagoXIV/Rando/Logic.cs
+++ b/ArchipelagoXIV/Rando/Logic.cs
@@ -23,10 +23,10 @@ namespace ArchipelagoXIV.Rando
             var rules = (from Match m in Regexes.itemRegex.Matches(requires)
                          select HasItem(m.Groups[0].Value)).ToArray();
             if (rules.Length != 0)
-                if(requires.Contains(" or "))
+                if(requires.Contains("| or |"))
                     return (state, asCurrentClass) => rules.Any(r => r(state, asCurrentClass));
                 else
-                    return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
+                return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
             if (string.IsNullOrEmpty(requires))
                 return Always();
             DalamudApi.Echo($"Could not parse Requires string: {requires}");

--- a/ArchipelagoXIV/Rando/Logic.cs
+++ b/ArchipelagoXIV/Rando/Logic.cs
@@ -23,7 +23,10 @@ namespace ArchipelagoXIV.Rando
             var rules = (from Match m in Regexes.itemRegex.Matches(requires)
                          select HasItem(m.Groups[0].Value)).ToArray();
             if (rules.Length != 0)
-                return (state, asCurrentClass) => rules.Any(r => r(state, asCurrentClass));
+                if(requires.Contains(" or "))
+                    return (state, asCurrentClass) => rules.Any(r => r(state, asCurrentClass));
+                else
+                    return (state, asCurrentClass) => rules.All(r => r(state, asCurrentClass));
             if (string.IsNullOrEmpty(requires))
                 return Always();
             DalamudApi.Echo($"Could not parse Requires string: {requires}");


### PR DESCRIPTION
This fixes a bug with backwards compatibility, where raid tiers that have transitioned to access items would require both items in plugin, rather than any item