### PR TITLE
Exclude achievement FATEs

### DIFF
--- a/src/hooks/Data.py
+++ b/src/hooks/Data.py
@@ -86,6 +86,38 @@ BOSS_GOAL_DATA: dict[str, tuple[str, str, int]] = {
     "Defeat Necron":               ("Ageless Necropolis",   "Living Memory",    100),
 }
 
+ACHIEVEMENT_FATES = [
+    "Poor Maid's Misfortune",
+    "It's Not Lupus",
+    "Lazy for You",
+    "Clearing the Hive",
+    "Defending the Hive",
+    "Keeping the Hive",
+    "Attack on Highbridge: Act III",
+    "Dark Devices - The End",
+    "Go, Go, Gorgimera",
+    "Svara's Fall",
+    "Svara's Fury",
+    "The Eyes Have It (FATE)",
+    "We Fought a Dzu",
+    "Special Tarasque Force",
+    "Darkscale Devoureth",
+    "Vedrfolnir Devoteth",
+    "On Dangerous Ground",
+    "Metal Gears Revengeance 2",
+    "The Evil Seed",
+    "Rattle and Humbaba",
+    "Tall Tale",
+    "Never Say Daimyo",
+    "The Dataqi Chronicles: Dominion",
+    "Wham, Bam, Thank You, Mammoth",
+    "Curiosity Killed the Catfish",
+    #"Deadly Nightshade", Currently in UNREASONABLE_FATES, this could possibly be moved to this group?
+    "Fuath to Be Reckoned With",
+    "Tojil Eclipse",
+    "The Elderblade"
+    ]
+
 UNREASONABLE_FATES = [
     "Behold Now Behemoth", "He Taketh It with His Eyes (FATE)", "Steel Reign (FATE)",
     "Long Live the Coeurl (FATE)", "Coeurls Chase Boys (FATE)", "Coeurls Chase Boys Chase Coeurls (FATE)", "Prey Online (FATE)",

--- a/src/hooks/Options.py
+++ b/src/hooks/Options.py
@@ -54,6 +54,15 @@ class Fatesanity(Toggle):
     display_name = "Fatesanity"
     default = False
 
+class AchievementFates(Toggle):
+    """
+    Include Achievement FATTEs and other FATEs that are not reasonable to complete.
+
+    These fates can either require large amounts of players or long/messy chains.
+    """
+    display_name = "Include Achievement FATEs"
+    default = False
+
 class UnreasonableFates(Toggle):
     """
     Include World Bosses and other FATEs that are not reasonable to complete.
@@ -494,6 +503,7 @@ def before_options_defined(options: dict) -> dict:
     # Fates
     options["fates_per_zone"] = FatesPerZone
     options["fatesanity"] = Fatesanity
+    options["include_achievement_fates"] = AchievementFates
     options["include_unreasonable_fates"] = UnreasonableFates
     options["include_fetes"] = Fetesanity
 
@@ -542,7 +552,7 @@ def after_options_defined(options: type[PerGameCommonOptions]) -> None:
 # Use this Hook if you want to add your Option to an Option group (existing or not)
 def before_option_groups_created(groups: dict[str, list[type[Option]]]) -> dict[str, list[type[Option]]]:
     groups["Character Settings"] = [LevelCap, ForceJob, ExcludeJob]
-    groups["Fates"] = [Fatesanity, FatesPerZone, UnreasonableFates, Fetesanity]
+    groups["Fates"] = [Fatesanity, FatesPerZone, AchievementFates, UnreasonableFates, Fetesanity]
     groups["Fishsanity"] = [Fishsanity, FishsanityDisableStartingBait, OceanFishing]
     groups["Huntsanity"] = [Huntsanity]
     groups["Field Operations"] = [IncludeBozja, IncludeOccultCrescent, FieldOperationCriticalEncounterCount, IncludeDuels]

--- a/src/hooks/World.py
+++ b/src/hooks/World.py
@@ -22,7 +22,7 @@ from ..Helpers import get_option_value, is_option_enabled
 # Object classes from Manual -- extending AP core -- representing items and locations that are used in generation
 from ..Items import ManualItem, item_name_to_item
 from ..Locations import victory_names, location_name_to_location
-from .Data import BOSS_GOAL_DATA, UNREASONABLE_FATES, categorizedLocationNames, bait_to_fish, FILLER_NAMES, FILLER_WEIGHTS
+from .Data import BOSS_GOAL_DATA, ACHIEVEMENT_FATES, UNREASONABLE_FATES, categorizedLocationNames, bait_to_fish, FILLER_NAMES, FILLER_WEIGHTS
 from .Helpers import get_int_value, is_fishing_enabled, get_excluded_jobs, get_set_value
 from .Options import LevelCap
 from .common import CASTER, DOH, HEALERS, MELEE, RANGED, TANKS
@@ -255,6 +255,8 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
     locationNamesToRemove = []
     locationNamesToExclude = []
     empty_regions = []
+    if not is_option_enabled(multiworld, player, "include_achievement_fates"):
+        locationNamesToRemove.extend(ACHIEVEMENT_FATES)
     if not is_option_enabled(multiworld, player, "include_unreasonable_fates"):
         locationNamesToRemove.extend(UNREASONABLE_FATES)
 


### PR DESCRIPTION
This will allow people to include/exclude achievement fates(including the more annoying ones), while not forcing them to also include the world bosses if they do want to include them